### PR TITLE
stats mode 0.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.o
+decpcap_test
+nethogs

--- a/main.cpp
+++ b/main.cpp
@@ -36,7 +36,7 @@ int main (int argc, char** argv)
 	int promisc = 0;
 
 	int opt;
-	while ((opt = getopt(argc, argv, "Vhbtpd:v:c:s")) != -1) {
+	while ((opt = getopt(argc, argv, "Vhbtpd:v:c:s:z")) != -1) {
 		switch(opt) {
 			case 'V':
 				versiondisplay();
@@ -65,6 +65,9 @@ int main (int argc, char** argv)
 				break;
 			case 'c':
 				refreshlimit = atoi(optarg);
+				break;
+			case 'z':
+				stats = true;
 				break;
 			/*
 			case 'f':
@@ -96,8 +99,9 @@ int main (int argc, char** argv)
         }
 	}
 
-	if ((!tracemode) && (!DEBUG)){
+	if ((!tracemode) && (!DEBUG) && (!stats) ){
 		init_ui();
+		tracemode = stats;
 	}
 
 	if (NEEDROOT && (geteuid() != 0))
@@ -109,7 +113,8 @@ int main (int argc, char** argv)
 	device * current_dev = devices;
 	while (current_dev != NULL) {
 		getLocal(current_dev->name, tracemode);
-
+		getLocal(current_dev->name, stats);
+		
 		dp_handle * newhandle = dp_open_live(current_dev->name, BUFSIZ, promisc, 100, errbuf);
 		if (newhandle != NULL)
 		{
@@ -173,7 +178,7 @@ int main (int argc, char** argv)
 
 		if (needrefresh)
 		{
-			if ((!DEBUG)&&(!tracemode))
+			if ((!DEBUG)&&(!tracemode)&&(!stats))
 			{
 				// handle user input
 				ui_tick();

--- a/nethogs.cpp
+++ b/nethogs.cpp
@@ -66,6 +66,8 @@ int viewMode = VIEWMODE_KBPS;
 //dp_link_type linktype = dp_link_ethernet;
 const char version[] = " version " VERSION "." SUBVERSION "." MINORVERSION;
 
+bool stats = false;
+
 timeval curtime;
 
 bool local_addr::contains (const in_addr_t & n_addr) {

--- a/process.h
+++ b/process.h
@@ -29,6 +29,7 @@
 
 extern bool tracemode;
 extern bool bughuntmode;
+extern bool stats;
 
 void check_all_procs ();
 


### PR DESCRIPTION
Stats mode: 
- New flag: -z (did not find anything better)
- Based pretty much on tracemode, but:
  - Record the name of the application that used bandwidth and keep track for that name
  - It allows to do statistics about what applications are consuming the most (no per process)
  - There is no time out for applications, so at the end of the day we can track the whole day
 