### PR TITLE
Replace usleep() with select() to reduce CPU usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+nethogs
+decpcap_test
+TAGS
+*.o
+*~

--- a/cui.cpp
+++ b/cui.cpp
@@ -222,7 +222,7 @@ static void wait_for_input(){
 
 	FD_ZERO(&fds);
 	FD_SET(STDIN_FILENO, &fds);
-	int status = select(maxfd + 1, &fds, 0, 0, 0);
+	int status = select(maxfd + 1, &fds, NULL, NULL, NULL);
 
 	if(status == -1){
 	  switch (errno) {

--- a/cui.cpp
+++ b/cui.cpp
@@ -35,6 +35,7 @@
 
 
 std::string * caption;
+extern bool needrefresh;
 extern const char version[];
 extern ProcList * processes;
 extern timeval curtime;
@@ -215,6 +216,18 @@ void exit_ui ()
 
 void ui_tick ()
 {
+	fd_set fds;
+	
+	int maxfd = 0; // stdin
+
+	FD_ZERO(&fds);
+	FD_SET(0, &fds);
+	int status = select(maxfd + 1, &fds, 0, 0, 0);
+	
+	if(status == -1){
+	  std::cerr << "select error: " << strerror(errno) << std::endl;
+	}
+
 	switch (getch()) {
 		case 'q':
 			/* quit */
@@ -223,14 +236,17 @@ void ui_tick ()
 		case 's':
 			/* sort on 'sent' */
 			sortRecv = false;
+			needrefresh = true;
 			break;
 		case 'r':
 			/* sort on 'received' */
 			sortRecv = true;
+			needrefresh = true;
 			break;
 		case 'm':
 			/* switch mode: total vs kb/s */
 			viewMode = (viewMode + 1) % VIEWMODE_COUNT;
+			needrefresh = true;
 			break;
 	}
 }

--- a/main.cpp
+++ b/main.cpp
@@ -171,23 +171,15 @@ int main (int argc, char** argv)
 		}
 
 
+		if ((!DEBUG)&&(!tracemode))
+		{
+		    // handle user input
+		    ui_tick();
+		}
 		if (needrefresh)
 		{
-			if ((!DEBUG)&&(!tracemode))
-			{
-				// handle user input
-				ui_tick();
-			}
 			do_refresh();
 			needrefresh = false;
-		}
-
-		//!@todo no periodic sleeping! Use a wakeup event.
-		// If no packets were read at all this iteration, pause to prevent 100%
-		// CPU utilisation;
-		if (!packets_read)
-		{
-			usleep(100);
 		}
 	}
 }

--- a/main.cpp
+++ b/main.cpp
@@ -151,8 +151,6 @@ int main (int argc, char** argv)
 	//  This causes the CPU utilisation to go up to 100%. This is tricky:
 	while (1)
 	{
-		bool packets_read = false;
-
 		handle * current_handle = handles;
 		while (current_handle != NULL)
 		{
@@ -162,10 +160,6 @@ int main (int argc, char** argv)
 			if (retval < 0)
 			{
 				std::cerr << "Error dispatching: " << retval << std::endl;
-			}
-			else if (retval != 0)
-			{
-				packets_read = true;
 			}
 			current_handle = current_handle->next;
 		}

--- a/main.cpp
+++ b/main.cpp
@@ -182,6 +182,7 @@ int main (int argc, char** argv)
 			needrefresh = false;
 		}
 
+		//!@todo no periodic sleeping! Use a wakeup event.
 		// If no packets were read at all this iteration, pause to prevent 100%
 		// CPU utilisation;
 		if (!packets_read)


### PR DESCRIPTION
  Replace usleep() with select().
    
This prevents unnecessary wakeups just to check for user input, and reduces CPU usage from 5% to 0% when idle.
