### PR TITLE
Fixed buffer overflow for cmdline strings of length >= 80

### DIFF
--- a/inode2prog.h
+++ b/inode2prog.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * inode2prog.h
  *
  * Copyright (c) 2005,2008 Arnout Engelen
@@ -30,13 +30,13 @@
 struct prg_node {
     long inode;
     pid_t pid;
-    char * name;
+    std::string name;
 };
 
 struct prg_node * findPID (unsigned long inode);
 
 void prg_cache_clear();
- 
+
 // reread the inode-to-prg_node-mapping
 void reread_mapping ();
 

--- a/process.cpp
+++ b/process.cpp
@@ -165,7 +165,7 @@ Process * getProcess (unsigned long inode, const char * devicename)
 	if (proc != NULL)
 		return proc;
 
-	Process * newproc = new Process (inode, devicename, node->name);
+	Process * newproc = new Process (inode, devicename, node->name.c_str());
 	newproc->pid = node->pid;
 
 	char procdir [100];


### PR DESCRIPTION
This pull request is meant to accompany Issue #7. The main goal was to fix the missing null terminator (not technically a buffer overflow, I suppose, but not sure what to call it), but there was also a memory leak from the `strdup`, and the 80 character limit seemed relatively arbitrary, so I've changed the type of prg_node::name to an `std::string` instead of a `char*`.

There is the potentially unwanted side effect that the program name will be shown with the trailing part instead of the leading, but I'm not sure what the correct solution for that is (truncate? left align and scroll?), so I've let that be. If desired, I'll gladly add the 80 character limit back in, though I think the true solution is something at the UI level and not the data level.