### PR TITLE
Use CPPFLAGS in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,37 +46,37 @@ uninstall:
 	rm $(DESTDIR)$(sbin)/nethogs
 	rm $(DESTDIR)$(man8)/nethogs.8
 
-test: test.cpp 
-	$(CXX) $(CXXFLAGS) $(LDFLAGS) test.cpp -o test -lpcap -lm ${NCURSES_LIBS} -DVERSION=\"$(VERSION)\" -DSUBVERSION=\"$(SUBVERSION)\" -DMINORVERSION=\"$(MINORVERSION)\"
+test: test.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(LDFLAGS) test.cpp -o test -lpcap -lm ${NCURSES_LIBS} -DVERSION=\"$(VERSION)\" -DSUBVERSION=\"$(SUBVERSION)\" -DMINORVERSION=\"$(MINORVERSION)\"
 
 nethogs: main.cpp nethogs.cpp $(OBJS)
-	$(CXX) $(CXXFLAGS) $(LDFLAGS) main.cpp $(OBJS) -o nethogs -lpcap -lm ${NCURSES_LIBS} -DVERSION=\"$(VERSION)\" -DSUBVERSION=\"$(SUBVERSION)\" -DMINORVERSION=\"$(MINORVERSION)\"
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(LDFLAGS) main.cpp $(OBJS) -o nethogs -lpcap -lm ${NCURSES_LIBS} -DVERSION=\"$(VERSION)\" -DSUBVERSION=\"$(SUBVERSION)\" -DMINORVERSION=\"$(MINORVERSION)\"
 nethogs_testsum: nethogs_testsum.cpp $(OBJS)
-	$(CXX) $(CXXFLAGS) $(LDFLAGS) nethogs_testsum.cpp $(OBJS) -o nethogs_testsum -lpcap -lm ${NCURSES_LIBS} -DVERSION=\"$(VERSION)\" -DSUBVERSION=\"$(SUBVERSION)\" -DMINORVERSION=\"$(MINORVERSION)\"
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(LDFLAGS) nethogs_testsum.cpp $(OBJS) -o nethogs_testsum -lpcap -lm ${NCURSES_LIBS} -DVERSION=\"$(VERSION)\" -DSUBVERSION=\"$(SUBVERSION)\" -DMINORVERSION=\"$(MINORVERSION)\"
 
 decpcap_test: decpcap_test.cpp decpcap.o
-	$(CXX) $(CXXFLAGS) $(LDFLAGS) decpcap_test.cpp decpcap.o -o decpcap_test -lpcap -lm
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(LDFLAGS) decpcap_test.cpp decpcap.o -o decpcap_test -lpcap -lm
 
 #-lefence
 
 refresh.o: refresh.cpp refresh.h nethogs.h
-	$(CXX) $(CXXFLAGS) -c refresh.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c refresh.cpp
 process.o: process.cpp process.h nethogs.h
-	$(CXX) $(CXXFLAGS) -c process.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c process.cpp
 packet.o: packet.cpp packet.h nethogs.h
-	$(CXX) $(CXXFLAGS) -c packet.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c packet.cpp
 connection.o: connection.cpp connection.h nethogs.h
-	$(CXX) $(CXXFLAGS) -c connection.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c connection.cpp
 decpcap.o: decpcap.c decpcap.h
-	$(CC) $(CFLAGS) -c decpcap.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c decpcap.c
 inode2prog.o: inode2prog.cpp inode2prog.h nethogs.h
-	$(CXX) $(CXXFLAGS) -c inode2prog.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c inode2prog.cpp
 conninode.o: conninode.cpp nethogs.h conninode.h
-	$(CXX) $(CXXFLAGS) -c conninode.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c conninode.cpp
 #devices.o: devices.cpp devices.h
 #	$(CXX) $(CXXFLAGS) -c devices.cpp
 cui.o: cui.cpp cui.h nethogs.h
-	$(CXX) $(CXXFLAGS) -c cui.cpp -DVERSION=\"$(VERSION)\" -DSUBVERSION=\"$(SUBVERSION)\" -DMINORVERSION=\"$(MINORVERSION)\"
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c cui.cpp -DVERSION=\"$(VERSION)\" -DSUBVERSION=\"$(SUBVERSION)\" -DMINORVERSION=\"$(MINORVERSION)\"
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Hello,

When you need to use a custom include directory, it is pretty useful to have a Makefile that uses CPPFLAGS.
(Also a lot of package managers use this flag to ensure the correct headers are used.)