### PR TITLE
Truncate user names when necessary (fixes #28) and fix alignment of sent/received fields

### DIFF
--- a/cui.cpp
+++ b/cui.cpp
@@ -57,6 +57,7 @@ const int COLUMN_WIDTH_USER =  8;
 const int COLUMN_WIDTH_DEV =  5;
 const int COLUMN_WIDTH_SENT = 11;
 const int COLUMN_WIDTH_RECEIVED = 11;
+const int COLUMN_WIDTH_UNIT = 6;
 
 const char * COLUMN_FORMAT_PID = "%7d";
 const char * COLUMN_FORMAT_SENT = "%11.3f";
@@ -166,23 +167,16 @@ void Line::show (int row, unsigned int proglen)
 	else
 		mvprintw (row, column_offset_pid, COLUMN_FORMAT_PID, m_pid);
 
-	// USER column
 	std::string username = uid2username(m_uid);
 	mvaddstr_truncate_trailing (row, column_offset_user, username.c_str(), username.size(), COLUMN_WIDTH_USER);
 
-	// PROGRAM column
 	mvaddstr_truncate_leading (row, column_offset_program, m_name, strlen (m_name), proglen);
 
-	// DEV column
 	mvaddstr (row, column_offset_dev, devicename);
 
-	// SENT column
 	mvprintw (row, column_offset_sent, COLUMN_FORMAT_SENT, sent_value);
 
-	// RECEIVED column
 	mvprintw (row, column_offset_received, COLUMN_FORMAT_RECEIVED, recv_value);
-
-	// Unit column
 	if (viewMode == VIEWMODE_KBPS)
 	{
 		mvaddstr (row, column_offset_unit, "KB/sec");
@@ -442,16 +436,16 @@ void show_ncurses(Line * lines[], int nproc) {
 
 	attron(A_REVERSE);
 	int totalrow = std::min(rows-1, 3+1+i);
-	mvprintw (totalrow, 0, "  TOTAL        %-*.*s          %10.3f  %10.3f ", proglen, proglen, " ", sent_global, recv_global);
+	mvprintw (totalrow, 0, "  TOTAL        %-*.*s          %11.3f %11.3f ", proglen, proglen, " ", sent_global, recv_global);
 	if (viewMode == VIEWMODE_KBPS)
 	{
-		mvprintw (3+1+i, cols - 7, "KB/sec ");
+		mvprintw (3+1+i, cols - COLUMN_WIDTH_UNIT, "KB/sec ");
 	} else if (viewMode == VIEWMODE_TOTAL_B) {
-		mvprintw (3+1+i, cols - 7, "B      ");
+		mvprintw (3+1+i, cols - COLUMN_WIDTH_UNIT, "B      ");
 	} else if (viewMode == VIEWMODE_TOTAL_KB) {
-		mvprintw (3+1+i, cols - 7, "KB     ");
+		mvprintw (3+1+i, cols - COLUMN_WIDTH_UNIT, "KB     ");
 	} else if (viewMode == VIEWMODE_TOTAL_MB) {
-		mvprintw (3+1+i, cols - 7, "MB     ");
+		mvprintw (3+1+i, cols - COLUMN_WIDTH_UNIT, "MB     ");
 	}
 	attroff(A_REVERSE);
 	mvprintw (totalrow+1, 0, "");

--- a/cui.cpp
+++ b/cui.cpp
@@ -52,6 +52,16 @@ extern unsigned refreshcount;
 
 #define PID_MAX 4194303
 
+const int COLUMN_WIDTH_PID =  7;
+const int COLUMN_WIDTH_USER =  8;
+const int COLUMN_WIDTH_DEV =  5;
+const int COLUMN_WIDTH_SENT = 11;
+const int COLUMN_WIDTH_RECEIVED = 11;
+
+const char * COLUMN_FORMAT_PID = "%7d";
+const char * COLUMN_FORMAT_SENT = "%11.3f";
+const char * COLUMN_FORMAT_RECEIVED = "%11.3f";
+
 class Line
 {
 public:
@@ -109,47 +119,85 @@ std::string uid2username (uid_t uid)
 		return std::string(pwd->pw_name);
 }
 
+/**
+ * Render the provided text at the specified location, truncating if the length of the text exceeds a maximum. If the
+ * text must be truncated, the string ".." will be rendered, followed by max_len - 2 characters of the provided text.
+ */
+static void mvaddstr_truncate_leading(int row, int col, const char* str, std::size_t str_len, std::size_t max_len)
+{
+	if (str_len < max_len) {
+		mvaddstr(row, col, str);
+	} else {
+		mvaddstr(row, col, "..");
+		addnstr(str + 2, max_len - 2);
+	}
+}
+
+/**
+ * Render the provided text at the specified location, truncating if the length of the text exceeds a maximum. If the
+ * text must be truncated, the text will be rendered up to max_len - 2 characters and then ".." will be rendered.
+ */
+static void mvaddstr_truncate_trailing(int row, int col, const char* str, std::size_t str_len, std::size_t max_len)
+{
+	if (str_len < max_len) {
+		mvaddstr(row, col, str);
+	} else {
+		mvaddnstr(row, col, str, max_len - 2);
+		addstr("..");
+	}
+}
 
 void Line::show (int row, unsigned int proglen)
 {
 	assert (m_pid >= 0);
 	assert (m_pid <= PID_MAX);
 
+	const int column_offset_pid = 0;
+	const int column_offset_user = column_offset_pid + COLUMN_WIDTH_PID + 1;
+	const int column_offset_program = column_offset_user + COLUMN_WIDTH_USER + 1;
+	const int column_offset_dev = column_offset_program + proglen + 2;
+	const int column_offset_sent = column_offset_dev + COLUMN_WIDTH_DEV + 1;
+	const int column_offset_received = column_offset_sent + COLUMN_WIDTH_SENT + 1;
+	const int column_offset_unit = column_offset_received + COLUMN_WIDTH_RECEIVED + 1;
+
+	// PID column
 	if (m_pid == 0)
-		mvprintw (row, 6, "?");
+		mvaddch (row, column_offset_pid + COLUMN_WIDTH_PID - 1, '?');
 	else
-		mvprintw (row, 0, "%7d", m_pid);
+		mvprintw (row, column_offset_pid, COLUMN_FORMAT_PID, m_pid);
+
+	// USER column
 	std::string username = uid2username(m_uid);
-	mvprintw (row, 8, "%s", username.c_str());
-	if (strlen (m_name) > proglen) {
-		// truncate oversized names
-		char * tmp = strdup(m_name);
-		char * start = tmp + strlen (m_name) - proglen;
-		start[0] = '.';
-		start[1] = '.';
-		mvprintw (row, 8 + 9, "%s", start);
-		free (tmp);
-	} else {
-		mvprintw (row, 8 + 9, "%s", m_name);
-	}
-	mvprintw (row, 8 + 9 + proglen + 2, "%s", devicename);
-	mvprintw (row, 8 + 9 + proglen + 2 + 6, "%10.3f", sent_value);
-	mvprintw (row, 8 + 9 + proglen + 2 + 6 + 9 + 3, "%10.3f", recv_value);
+	mvaddstr_truncate_trailing (row, column_offset_user, username.c_str(), username.size(), COLUMN_WIDTH_USER);
+
+	// PROGRAM column
+	mvaddstr_truncate_leading (row, column_offset_program, m_name, strlen (m_name), proglen);
+
+	// DEV column
+	mvaddstr (row, column_offset_dev, devicename);
+
+	// SENT column
+	mvprintw (row, column_offset_sent, COLUMN_FORMAT_SENT, sent_value);
+
+	// RECEIVED column
+	mvprintw (row, column_offset_received, COLUMN_FORMAT_RECEIVED, recv_value);
+
+	// Unit column
 	if (viewMode == VIEWMODE_KBPS)
 	{
-		mvprintw (row, 8 + 9 + proglen + 2 + 6 + 9 + 3 + 11, "KB/sec");
+		mvaddstr (row, column_offset_unit, "KB/sec");
 	}
 	else if (viewMode == VIEWMODE_TOTAL_MB)
 	{
-		mvprintw (row, 8 + 9 + proglen + 2 + 6 + 9 + 3 + 11, "MB    ");
+		mvaddstr (row, column_offset_unit, "MB    ");
 	}
 	else if (viewMode == VIEWMODE_TOTAL_KB)
 	{
-		mvprintw (row, 8 + 9 + proglen + 2 + 6 + 9 + 3 + 11, "KB    ");
+		mvaddstr (row, column_offset_unit, "KB    ");
 	}
 	else if (viewMode == VIEWMODE_TOTAL_B)
 	{
-		mvprintw (row, 8 + 9 + proglen + 2 + 6 + 9 + 3 + 11, "B     ");
+		mvaddstr (row, column_offset_unit, "B     ");
 	}
 }
 


### PR DESCRIPTION
* Fixes #28 -- the username would overflow and mix in with the program name
* Unit column no longer leaves an unnecessary empty space at the end of the line. 
* Received column lines up correctly to the RECEIVED label (are the SENT header and the column values purposely offset???)

Hopefully I'm not stepping on anyone's toes since this issue wasn't tagged as help-wanted, but it seemed easy and a nice improvement. I'm a bit confused on what style to use since the README.md says braces on same lines for conditionals but the code has a mix of everything, so I went with same line. Also, hopefully my refactoring hasn't gone too far... It was a bit overwhelming to see so many numbers shuffling around :).

Before:
![before](https://cloud.githubusercontent.com/assets/892339/13419419/ad69e990-df43-11e5-89e1-c4af1af8c254.png)

Note the "KB/sec" has a trailing space, "0.114" isn't lined up with RECEIVED, and the username has overflowed its column and has "curl" in the middle of it.

After:
![after](https://cloud.githubusercontent.com/assets/892339/13419424/b0c6a2a4-df43-11e5-94a6-3025f1ccb83a.png)

The trailing space is fixed, "0.114" lines up with RECEIVED, and the username is truncated. I thought the prefixed continuation looked a bit odd with usernames so I went with suffixed, but I can change that if preferred.