### PR TITLE
fix stack buffer overflow when convert between in6_addr

### DIFF
--- a/src/conninode.cpp
+++ b/src/conninode.cpp
@@ -60,8 +60,8 @@ std::map<std::string, unsigned long> conninode;
  */
 void addtoconninode(char *buffer) {
   short int sa_family;
-  struct in6_addr result_addr_local;
-  struct in6_addr result_addr_remote;
+  struct in6_addr result_addr_local = {};
+  struct in6_addr result_addr_remote = {};
 
   char rem_addr[128], local_addr[128];
   int local_port, rem_port;
@@ -102,8 +102,8 @@ void addtoconninode(char *buffer) {
     if ((in6_local.s6_addr32[0] == 0x0) && (in6_local.s6_addr32[1] == 0x0) &&
         (in6_local.s6_addr32[2] == 0xFFFF0000)) {
       /* IPv4-compatible address */
-      result_addr_local = *((struct in6_addr *)&(in6_local.s6_addr32[3]));
-      result_addr_remote = *((struct in6_addr *)&(in6_remote.s6_addr32[3]));
+      result_addr_local.s6_addr32[0]  = in6_local.s6_addr32[3];
+      result_addr_remote.s6_addr32[0] = in6_remote.s6_addr32[3];
       sa_family = AF_INET;
     } else {
       /* real IPv6 address */


### PR DESCRIPTION
original code 
result_addr_local  = *((struct in6_addr*) &(in6_local.s6_addr32[3]));
result_addr_remote = *((struct in6_addr*) &(in6_remote.s6_addr32[3]));

access memory out of variable bound . 
ASAN reports:

=================================================================
==2059==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7ffc55058eac at pc 0x4145c3 bp 0x7ffc55058cc0 sp 0x7ffc55058cb0
READ of size 16 at 0x7ffc55058eac thread T0
    #0 0x4145c2 in addtoconninode(char*) /usr/src/debug/net-analyzer/nethogs-0.8.1/nethogs-0.8.1/conninode.cpp:96
    #1 0x41468c in addprocinfo(char const*) /usr/src/debug/net-analyzer/nethogs-0.8.1/nethogs-0.8.1/conninode.cpp:165
    #2 0x40a9f9 in getProcess(Connection*, char const*) /usr/src/debug/net-analyzer/nethogs-0.8.1/nethogs-0.8.1/process.cpp:225
    #3 0x40526b in process_tcp(unsigned char*, pcap_pkthdr const*, unsigned char const*) /usr/src/debug/net-analyzer/nethogs-0.8.1/nethogs-0.8.1/nethogs.cpp:147
    #4 0x40d2bd in dp_pcap_callback /usr/src/debug/net-analyzer/nethogs-0.8.1/nethogs-0.8.1/decpcap.c:304
    #5 0x7f5f60e68e15 (/usr/lib64/libpcap.so.1+0x1de15)
    #6 0x7f5f60e75ed2 (/usr/lib64/libpcap.so.1+0x2aed2)
    #7 0x403eaf in main /usr/src/debug/net-analyzer/nethogs-0.8.1/nethogs-0.8.1/main.cpp:161
    #8 0x7f5f602d859f in __libc_start_main (/lib64/libc.so.6+0x2059f)
    #9 0x404928 in _start (/usr/sbin/nethogs+0x404928)

Address 0x7ffc55058eac is located in stack of thread T0 at offset 364 in frame
    #0 0x4133af in addtoconninode(char*) /usr/src/debug/net-analyzer/nethogs-0.8.1/nethogs-0.8.1/conninode.cpp:52

  This frame has 9 object(s):
    [32, 36) 'local_port'
    [96, 100) 'rem_port'
    [160, 168) 'inode'
    [224, 240) 'result_addr_local'
    [288, 304) 'result_addr_remote'
    [352, 368) 'in6_local' <== Memory access at offset 364 partially overflows this variable
    [416, 432) 'in6_remote'
    [480, 608) 'rem_addr'
    [640, 768) 'local_addr'
HINT: this may be a false positive if your program uses some custom stack unwind mechanism or swapcontext
      (longjmp and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: stack-buffer-overflow /usr/src/debug/net-analyzer/nethogs-0.8.1/nethogs-0.8.1/conninode.cpp:96 addtoconninode(char*)
Shadow bytes around the buggy address:
  0x10000aa03180: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10000aa03190: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10000aa031a0: 00 00 00 00 00 00 00 00 f1 f1 f1 f1 04 f4 f4 f4
  0x10000aa031b0: f2 f2 f2 f2 04 f4 f4 f4 f2 f2 f2 f2 00 f4 f4 f4
  0x10000aa031c0: f2 f2 f2 f2 00 00 f4 f4 f2 f2 f2 f2 00 00 f4 f4
=>0x10000aa031d0: f2 f2 f2 f2 00[00]f4 f4 f2 f2 f2 f2 00 00 f4 f4
  0x10000aa031e0: f2 f2 f2 f2 00 00 00 00 00 00 00 00 00 00 00 00
  0x10000aa031f0: 00 00 00 00 f2 f2 f2 f2 00 00 00 00 00 00 00 00
  0x10000aa03200: 00 00 00 00 00 00 00 00 f3 f3 f3 f3 00 00 00 00
  0x10000aa03210: 00 00 00 00 00 00 00 00 f1 f1 f1 f1 00 00 00 00
  0x10000aa03220: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Heap right redzone:      fb
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack partial redzone:   f4
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Contiguous container OOB:fc
  ASan internal:           fe
==2059==ABORTING
