### PR TITLE
Detect capabilities when NEEDROOT=0

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -177,9 +177,11 @@ int main(int argc, char **argv) {
   if (geteuid() != 0)
     forceExit(false, "You need to be root to run NetHogs!");
 #else
+  char exe_path[PATH_MAX];
   unsigned int caps[5] = {0};
 
-  getxattr(argv[0], "security.capability", (char *)caps, sizeof(caps));
+  readlink("/proc/self/exe", exe_path, PATH_MAX);
+  getxattr(exe_path, "security.capability", (char *)caps, sizeof(caps));
 
   if (((caps[1] >> CAP_NET_ADMIN) & 1) != 1)
     forceExit(false, "You need to enable cap_net_admin (and cap_net_raw) to run NetHogs!");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -173,20 +173,19 @@ int main(int argc, char **argv) {
     init_ui();
   }
 
-  if (NEEDROOT) {
-    if (geteuid() != 0)
-      forceExit(false, "You need to be root to run NetHogs!");
-  }
-  else {
-    unsigned int caps[5] = {0};
+#if NEEDROOT == 1
+  if (geteuid() != 0)
+    forceExit(false, "You need to be root to run NetHogs!");
+#else
+  unsigned int caps[5] = {0};
 
-    getxattr(argv[0], "security.capability", (char *)caps, sizeof(caps));
+  getxattr(argv[0], "security.capability", (char *)caps, sizeof(caps));
 
-    if ((caps[1] >> CAP_NET_ADMIN) & 1 != 1)
-      forceExit(false, "You need to enable cap_net_admin (and cap_net_raw) to run NetHogs!");
-    if ((caps[1] >> CAP_NET_RAW) & 1 != 1)
-      forceExit(false, "You need to enable cap_net_raw to run NetHogs!");
-  }
+  if (((caps[1] >> CAP_NET_ADMIN) & 1) != 1)
+    forceExit(false, "You need to enable cap_net_admin (and cap_net_raw) to run NetHogs!");
+  if (((caps[1] >> CAP_NET_RAW) & 1) != 1)
+    forceExit(false, "You need to enable cap_net_raw to run NetHogs!");
+#endif
 
   // use the Self-Pipe trick to interrupt the select() in the main loop
   self_pipe = create_self_pipe();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -182,9 +182,9 @@ int main(int argc, char **argv) {
 
     getxattr(argv[0], "security.capability", (char *)caps, sizeof(caps));
 
-    if ((val[1] >> CAP_NET_ADMIN) & 1 != 1)
+    if ((caps[1] >> CAP_NET_ADMIN) & 1 != 1)
       forceExit(false, "You need to enable cap_net_admin (and cap_net_raw) to run NetHogs!");
-    if ((val[1] >> CAP_NET_RAW) & 1 != 1)
+    if ((caps[1] >> CAP_NET_RAW) & 1 != 1)
       forceExit(false, "You need to enable cap_net_raw to run NetHogs!");
   }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -173,8 +173,20 @@ int main(int argc, char **argv) {
     init_ui();
   }
 
-  if (NEEDROOT && (geteuid() != 0))
-    forceExit(false, "You need to be root to run NetHogs!");
+  if (NEEDROOT) {
+    if (geteuid() != 0)
+      forceExit(false, "You need to be root to run NetHogs!");
+  }
+  else {
+    unsigned int caps[5] = {0};
+
+    getxattr(argv[0], "security.capability", (char *)caps, sizeof(caps));
+
+    if ((val[1] >> CAP_NET_ADMIN) & 1 != 1)
+      forceExit(false, "You need to enable cap_net_admin (and cap_net_raw) to run NetHogs!");
+    if ((val[1] >> CAP_NET_RAW) & 1 != 1)
+      forceExit(false, "You need to enable cap_net_raw to run NetHogs!");
+  }
 
   // use the Self-Pipe trick to interrupt the select() in the main loop
   self_pipe = create_self_pipe();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,14 @@
 #include <fcntl.h>
 #include <vector>
 
+#ifdef __linux__
+#include <linux/limits.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/xattr.h>
+#include <linux/capability.h>
+#endif
+
 // The self_pipe is used to interrupt the select() in the main loop
 static std::pair<int, int> self_pipe = std::make_pair(-1, -1);
 static time_t last_refresh_time = 0;
@@ -173,21 +181,20 @@ int main(int argc, char **argv) {
     init_ui();
   }
 
-#if NEEDROOT == 1
-  if (geteuid() != 0)
-    forceExit(false, "You need to be root to run NetHogs!");
+  if (geteuid() != 0) {
+#ifdef __linux__
+    char exe_path[PATH_MAX];
+    unsigned int caps[5] = {0};
+
+    readlink("/proc/self/exe", exe_path, PATH_MAX);
+    getxattr(exe_path, "security.capability", (char *)caps, sizeof(caps));
+
+    if ((((caps[1] >> CAP_NET_ADMIN) & 1) != 1) || (((caps[1] >> CAP_NET_RAW) & 1) != 1))
+      forceExit(false, "To run nethogs without being root you need to enable capabilities on the program (cap_net_admin, cap_net_raw), see the documentation for details.");
 #else
-  char exe_path[PATH_MAX];
-  unsigned int caps[5] = {0};
-
-  readlink("/proc/self/exe", exe_path, PATH_MAX);
-  getxattr(exe_path, "security.capability", (char *)caps, sizeof(caps));
-
-  if (((caps[1] >> CAP_NET_ADMIN) & 1) != 1)
-    forceExit(false, "You need to enable cap_net_admin (and cap_net_raw) to run NetHogs!");
-  if (((caps[1] >> CAP_NET_RAW) & 1) != 1)
-    forceExit(false, "You need to enable cap_net_raw to run NetHogs!");
+    forceExit(false, "You need to be root to run NetHogs!");
 #endif
+  }
 
   // use the Self-Pipe trick to interrupt the select() in the main loop
   self_pipe = create_self_pipe();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -184,9 +184,13 @@ int main(int argc, char **argv) {
   if (geteuid() != 0) {
 #ifdef __linux__
     char exe_path[PATH_MAX];
-    unsigned int caps[5] = {0};
+    ssize_t len;
+    unsigned int caps[5] = {0,0,0,0,0};
 
-    readlink("/proc/self/exe", exe_path, PATH_MAX);
+    if ((len = readlink("/proc/self/exe", exe_path, PATH_MAX)) == -1)
+      forceExit(false, "Failed to locate nethogs binary.");
+    exe_path[len] = '\0';
+
     getxattr(exe_path, "security.capability", (char *)caps, sizeof(caps));
 
     if ((((caps[1] >> CAP_NET_ADMIN) & 1) != 1) || (((caps[1] >> CAP_NET_RAW) & 1) != 1))

--- a/src/nethogs.cpp
+++ b/src/nethogs.cpp
@@ -39,6 +39,8 @@
 #include <netinet/udp.h>
 
 #if NEEDROOT == 0
+#include <linux/limits.h>
+#include <unistd.h>
 #include <sys/types.h>
 #include <sys/xattr.h>
 #include <linux/capability.h>

--- a/src/nethogs.cpp
+++ b/src/nethogs.cpp
@@ -37,9 +37,12 @@
 #include <netinet/ip6.h>
 #include <netinet/tcp.h>
 #include <netinet/udp.h>
+
+#if NEEDROOT == 0
 #include <sys/types.h>
 #include <sys/xattr.h>
 #include <linux/capability.h>
+#endif
 
 #include "cui.h"
 

--- a/src/nethogs.cpp
+++ b/src/nethogs.cpp
@@ -38,14 +38,6 @@
 #include <netinet/tcp.h>
 #include <netinet/udp.h>
 
-#if NEEDROOT == 0
-#include <linux/limits.h>
-#include <unistd.h>
-#include <sys/types.h>
-#include <sys/xattr.h>
-#include <linux/capability.h>
-#endif
-
 #include "cui.h"
 
 extern "C" {

--- a/src/nethogs.cpp
+++ b/src/nethogs.cpp
@@ -37,6 +37,9 @@
 #include <netinet/ip6.h>
 #include <netinet/tcp.h>
 #include <netinet/udp.h>
+#include <sys/types.h>
+#include <sys/xattr.h>
+#include <linux/capability.h>
 
 #include "cui.h"
 

--- a/src/nethogs.h
+++ b/src/nethogs.h
@@ -53,7 +53,7 @@
  * like www.adamantix.org: in that case nethogs shouldn't check if it's
  * running as root. Take care to give it sufficient privileges though. */
 #ifndef NEEDROOT
-#define NEEDROOT 1
+#define NEEDROOT 0
 #endif
 
 #define DEBUG 0

--- a/src/nethogs.h
+++ b/src/nethogs.h
@@ -49,13 +49,6 @@
  * after which a connection is removed */
 #define CONNTIMEOUT 50
 
-/* Set to '0' when compiling for a system that uses Linux Capabilities,
- * like www.adamantix.org: in that case nethogs shouldn't check if it's
- * running as root. Take care to give it sufficient privileges though. */
-#ifndef NEEDROOT
-#define NEEDROOT 1
-#endif
-
 #define DEBUG 0
 
 #define REVERSEHACK 0

--- a/src/nethogs.h
+++ b/src/nethogs.h
@@ -53,7 +53,7 @@
  * like www.adamantix.org: in that case nethogs shouldn't check if it's
  * running as root. Take care to give it sufficient privileges though. */
 #ifndef NEEDROOT
-#define NEEDROOT 0
+#define NEEDROOT 1
 #endif
 
 #define DEBUG 0


### PR DESCRIPTION
* src/main.cpp: Include header files for capabilities and attrs.
* src/nethogs.cpp: Add code to read and parse file attrs, and check for the required capabilities in the non-root case.

We read the security.capability fattr which is 4 unsigned integers, then extract the specific bits to check that the program has the capabilities needed.

I experimented with using prctl to test capabilities, it looks like a cleaner interface but was always returning 1 even when the capabilities did not apply.