### PR TITLE
Add -j for JSON structured data in tracemode

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,5 +1,9 @@
 Changelog
 
+30/04/16 (nemx)
+- added new command line switch:
+  -j Formats tracemode xfer data as newline delimited JSON (implies -t)
+
 12/05/13 (muzso)
 - added new command line switches:
   -s  Sorts output by the sent column.

--- a/src/cui.cpp
+++ b/src/cui.cpp
@@ -79,6 +79,7 @@ public:
 
   void show(int row, unsigned int proglen);
   void log();
+  void log_json();
 
   double sent_value;
   double recv_value;
@@ -199,6 +200,11 @@ void Line::log() {
             << "\t" << recv_value << std::endl;
 }
 
+void Line::log_json() {
+  printf("{\"name\":\"%s\",\"PID\":%d,\"UID\":%d,\"RX\":%f,\"TX\":%f }",
+        m_name, m_pid, m_uid, recv_value, sent_value);
+}
+
 int GreatestFirst(const void *ma, const void *mb) {
   Line **pa = (Line **)ma;
   Line **pb = (Line **)mb;
@@ -283,6 +289,17 @@ void show_trace(Line *lines[], int nproc) {
 
     curr_unknownconn = curr_unknownconn->getNext();
   }
+}
+
+void show_json_trace(Line *lines[], int nproc) {
+  /* print data */
+  std::cout << '[';
+  for (int i = 0; i < nproc; i++) {
+    lines[i]->log_json();
+    delete lines[i];
+    if (i != nproc - 1) std::cout << ',';
+  }
+  std::cout << ']' << std::endl;
 }
 
 void show_ncurses(Line *lines[], int nproc) {
@@ -396,7 +413,9 @@ void do_refresh() {
   /* sort the accumulated lines */
   qsort(lines, nproc, sizeof(Line *), GreatestFirst);
 
-  if (tracemode || DEBUG)
+  if (jsontrace)
+    show_json_trace(lines, nproc);
+  else if (tracemode || DEBUG)
     show_trace(lines, nproc);
   else
     show_ncurses(lines, nproc);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,7 +27,7 @@ static void help(bool iserror) {
   // output << "usage: nethogs [-V] [-b] [-d seconds] [-t] [-p] [-f (eth|ppp))]
   // [device [device [device ...]]]\n";
   output << "usage: nethogs [-V] [-h] [-b] [-d seconds] [-v mode] [-c count] "
-            "[-t] [-p] [-s] [device [device [device ...]]]\n";
+            "[-t] [-j] [-p] [-s] [device [device [device ...]]]\n";
   output << "		-V : prints version.\n";
   output << "		-h : prints this help.\n";
   output << "		-b : bughunt mode - implies tracemode.\n";
@@ -37,6 +37,7 @@ static void help(bool iserror) {
             "= total MB). default is 0.\n";
   output << "		-c : number of updates. default is 0 (unlimited).\n";
   output << "		-t : tracemode.\n";
+  output << "		-j : tracemode with data as newline-delimited json.\n";
   // output << "		-f : format of packets on interface, default is
   // eth.\n";
   output << "		-p : sniff in promiscious mode (not recommended).\n";
@@ -133,7 +134,7 @@ int main(int argc, char **argv) {
   bool all = false;
 
   int opt;
-  while ((opt = getopt(argc, argv, "Vahbtpd:v:c:sa")) != -1) {
+  while ((opt = getopt(argc, argv, "Vahbtjpd:v:c:sa")) != -1) {
     switch (opt) {
     case 'V':
       versiondisplay();
@@ -143,6 +144,10 @@ int main(int argc, char **argv) {
       exit(0);
     case 'b':
       bughuntmode = true;
+      tracemode = true;
+      break;
+    case 'j':
+      jsontrace = true;
       tracemode = true;
       break;
     case 't':

--- a/src/nethogs.cpp
+++ b/src/nethogs.cpp
@@ -57,6 +57,7 @@ unsigned refreshcount = 0;
 unsigned processlimit = 0;
 bool tracemode = false;
 bool bughuntmode = false;
+bool jsontrace = false;
 // sort on sent or received?
 bool sortRecv = true;
 // viewMode: kb/s or total

--- a/src/process.h
+++ b/src/process.h
@@ -28,6 +28,7 @@
 #include "connection.h"
 
 extern bool tracemode;
+extern bool jsontrace;
 extern bool bughuntmode;
 
 void check_all_procs();


### PR DESCRIPTION
Should resolve #64 and should help @akshayKMR simplify his webGUI project
A new flag (`-j`) is available to switch the trace data to json formatted (line delimited). I didn't want to go through the codebase adding a new flag (`jsontrace`) where-ever `tracemode` || `DEBUG` appeared, so I'm piggybacking off of `-t`, and _just_ swapping behavior right when it comes down to printing.

Also wanted to avoid rewriting all `cout`s, abstracting it into a general purpose logger that would choose between logging json or regular text, so there will be this output at the beginning of start-up:

Sample output:

```
Adding local address: 192.168.56.100
Adding local address: fe80::a00:27ff:feae:a7c6
Ethernet link detected
Adding local address: 10.0.2.15
Adding local address: fe80::a00:27ff:fe3a:2ddc
Ethernet link detected
Waiting for first packet to arrive (see sourceforge.net bug 1019381)
[{"name":"unknown TCP","PID":0,"UID":0,"RX":0.000000,"TX":0.000000 }]
[{"name":"sshd: nemix@pts/0","PID":827,"UID":1000,"RX":0.070312,"TX":0.339063 },{"name":"unknown TCP","PID":0,"UID":0,"RX":0.000000,"TX":0.000000 }]
[{"name":"sshd: nemix@pts/0","PID":827,"UID":1000,"RX":0.082031,"TX":0.416406 },{"name":"unknown TCP","PID":0,"UID":0,"RX":0.000000,"TX":0.000000 }]
[{"name":"sshd: nemix@pts/0","PID":827,"UID":1000,"RX":0.093750,"TX":0.493750 },{"name":"unknown TCP","PID":0,"UID":0,"RX":0.000000,"TX":0.000000 }]
[{"name":"sshd: nemix@pts/0","PID":827,"UID":1000,"RX":0.105469,"TX":0.571094 },{"name":"unknown TCP","PID":0,"UID":0,"RX":0.000000,"TX":0.000000 }]
```

Despite me not screwing with the initial output, it should be _incredibly_ trivial for client programs/consumers to skip lines that are not valid JSON, so that's primarily why I didn't go on a spree re-writing all the output calls.  I figure that it only matters to consumers that the data _itself_ is in JSON format.

Additionally, I didn't bother logging unknown connections since it seems like it's more intended for debugging, and I'm semi-torn on what a useful looking JSON structure might look like for it ... can be added in later if people really care for it ... but for the purposes of building GUIs or logging systems, this JSON output above should more than suffice.

Let me know if you have any thoughts, feedback, and/or want the change-log written differently

Cheers!

PS: I thought about logging to a file instead, but then ... considering this output is incredibly verbose, we'd need to talk about whether logrotation is our/your responsibility or the user's.  I've seen disks fill up in prod environments ruining everyone's day, so I think the current stdout usage is already great!
