### PR TITLE
Update readme to point to correct binary location

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ The master branch is intended to be stable at all times:
 
 #### Building
 
-After that, simply 
+After that, simply
 
     make
-    sudo ./nethogs
+    sudo ./src/nethogs
 
 #### Installing
 


### PR DESCRIPTION
After running `make`, I got a `nethogs` binary in the `src/` directory, not in
the root. I think that's intended since `make install` works fine, but the docs
for running before installing are wrong.