### PR TITLE
fix compiler warning - type of refreshdelay

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -157,7 +157,7 @@ int main(int argc, char **argv) {
       sortRecv = false;
       break;
     case 'd':
-      refreshdelay = atoi(optarg);
+      refreshdelay = (time_t) atoi(optarg);
       break;
     case 'v':
       viewMode = atoi(optarg) % VIEWMODE_COUNT;

--- a/src/nethogs.cpp
+++ b/src/nethogs.cpp
@@ -51,7 +51,7 @@ extern "C" {
 
 extern Process *unknownudp;
 
-unsigned refreshdelay = 1;
+time_t refreshdelay = 1;
 unsigned refreshlimit = 0;
 unsigned refreshcount = 0;
 unsigned processlimit = 0;


### PR DESCRIPTION
One more compiler warning (on i686 platform).