### PR TITLE
Bugfix: no install_dev target in docs/Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,6 @@ install_lib:
 
 install_dev:
 	$(MAKE) -C src -f MakeLib.mk $@
-	$(MAKE) -C doc $@
 
 uninstall:
 	$(MAKE) -C src -f MakeApp.mk $@


### PR DESCRIPTION
There is no `install_dev` target in the doc Makefile so `make install_dev` fails. 