### PR TITLE
issue #130 - libnethogs expose totals from closed connections

### DIFF
--- a/contrib/python-wrapper.py
+++ b/contrib/python-wrapper.py
@@ -54,6 +54,8 @@ class NethogsMonitorRecord(ctypes.Structure):
                 ('recv_bytes', ctypes.c_uint32),
                 ('sent_kbs', ctypes.c_float),
                 ('recv_kbs', ctypes.c_float),
+                ('sent_by_closed_bytes', ctypes.c_uint32),
+                ('recv_by_closed_bytes', ctypes.c_uint32),
                 )
 
 
@@ -93,6 +95,9 @@ def network_activity_callback(action, data):
     print('Device name: {}'.format(data.contents.device_name.decode('ascii')))
     print('Sent/Recv bytes: {} / {}'.format(data.contents.sent_bytes, data.contents.recv_bytes))
     print('Sent/Recv kbs: {} / {}'.format(data.contents.sent_kbs, data.contents.recv_kbs))
+    print('Sent/Recv bytes from closed connections: {} / {}'.format(
+        data.contents.sent_by_closed_bytes, data.contents.recv_by_closed_bytes
+    ))
     print('-' * 30)
 
 #############       Main begins here      ##############

--- a/src/libnethogs.cpp
+++ b/src/libnethogs.cpp
@@ -206,10 +206,13 @@ static void nethogsmonitor_handle_update(NethogsMonitorCallback cb) {
       const u_int32_t uid = curproc->getVal()->getUid();
       u_int32_t sent_bytes;
       u_int32_t recv_bytes;
+      u_int32_t sent_by_closed_bytes;
+      u_int32_t recv_by_closed_bytes;
       float sent_kbs;
       float recv_kbs;
       curproc->getVal()->getkbps(&recv_kbs, &sent_kbs);
       curproc->getVal()->gettotal(&recv_bytes, &sent_bytes);
+      curproc->getVal()->gettotalbyclosedconns(&recv_by_closed_bytes, &sent_by_closed_bytes);
 
       // notify update
       bool const new_data =
@@ -240,6 +243,8 @@ static void nethogsmonitor_handle_update(NethogsMonitorCallback cb) {
       NHM_UPDATE_ONE_FIELD(data.recv_bytes, recv_bytes)
       NHM_UPDATE_ONE_FIELD(data.sent_kbs, sent_kbs)
       NHM_UPDATE_ONE_FIELD(data.recv_kbs, recv_kbs)
+      NHM_UPDATE_ONE_FIELD(data.sent_by_closed_bytes, sent_by_closed_bytes)
+      NHM_UPDATE_ONE_FIELD(data.recv_by_closed_bytes, recv_by_closed_bytes)
 
 #undef NHM_UPDATE_ONE_FIELD
 

--- a/src/libnethogs.h
+++ b/src/libnethogs.h
@@ -28,6 +28,8 @@ typedef struct NethogsMonitorRecord {
   uint32_t recv_bytes;
   float sent_kbs;
   float recv_kbs;
+  uint32_t sent_by_closed_bytes;
+  uint32_t recv_by_closed_bytes;
 } NethogsMonitorRecord;
 
 /**

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -102,6 +102,9 @@ void Process::getkbps(float *recvd, float *sent) {
   ConnList *previous = NULL;
   while (curconn != NULL) {
     if (curconn->getVal()->getLastPacket() <= curtime.tv_sec - CONNTIMEOUT) {
+      /* capture sent and received totals before deleting */
+      this->sent_by_closed_bytes += curconn->getVal()->sumSent;
+      this->rcvd_by_closed_bytes += curconn->getVal()->sumRecv;
       /* stalled connection, remove. */
       ConnList *todelete = curconn;
       Connection *conn_todelete = curconn->getVal();
@@ -139,6 +142,13 @@ void Process::gettotal(u_int32_t *recvd, u_int32_t *sent) {
   // std::cout << "Sum recv: " << sum_recv << std::endl;
   *recvd = sum_recv;
   *sent = sum_sent;
+}
+
+/** get total values for closed connections from this process */
+/* closed connections aren't counted in gettotal() */
+void Process::gettotalbyclosedconns(u_int32_t *recvd, u_int32_t *sent) {
+  *recvd = this->rcvd_by_closed_bytes;
+  *sent = this->sent_by_closed_bytes;
 }
 
 void Process::gettotalmb(float *recvd, float *sent) {

--- a/src/process.h
+++ b/src/process.h
@@ -78,6 +78,8 @@ public:
     connections = NULL;
     pid = 0;
     uid = 0;
+    sent_by_closed_bytes = 0;
+    rcvd_by_closed_bytes = 0;
   }
   void check() { assert(pid >= 0); }
 
@@ -94,11 +96,14 @@ public:
   void gettotalmb(float *recvd, float *sent);
   void gettotalkb(float *recvd, float *sent);
   void gettotalb(float *recvd, float *sent);
+  void gettotalbyclosedconns(u_int32_t *recvd, u_int32_t *sent);
 
   char *name;
   char *cmdline;
   const char *devicename;
   int pid;
+  u_int32_t sent_by_closed_bytes;
+  u_int32_t rcvd_by_closed_bytes;
 
   ConnList *connections;
   uid_t getUid() { return uid; }


### PR DESCRIPTION
This implements the first proposed solution from [this comment](https://github.com/raboof/nethogs/issues/130#issuecomment-325125956) on #130:

1. Add fields to Process to store the total sent and recv bytes from closed connections, and a method to access these.
2. Increment those fields in Process::getkbps; when a Connection is deemed closed/stale, before removing it from the ConnList, add its sent/recv bytes counters to the Process's closed connection total bytes counters.
3. Add ``sent_by_closed_bytes`` and ``recv_by_closed_bytes`` fields to the libnethogs NethogsMonitorRecord struct.
4. In the libnethogs ``nethogsmonitor_handle_update()`` loop, call the new ``Process::gettotalbyclosedconns()`` and update the NethogsMonitorRecord with its result.

This results in a change to the public API of libnethogs (specifically, two new fields on NethogsMonitorRecord) but doesn't change how any of the existing fields are determined. If a libnethogs user wants to include closed connections in their totals, they can sum the fields of NethogsMonitorResult. This solution acknowledges that libnethogs and ``nethogs`` report (potentially very) different results, but preserves that behavior and lets the user choose whether they want the old behavior (open connections only; ``NethogsMonitorRecord.(sent|recv)_bytes``) or the same numbers as ``nethogs`` UI (sum ``NethogsMonitorRecord.(sent|recv)_bytes`` and ``NethogsMonitorRecord.(sent|recv)_by_closed_bytes``).

I've also opened #132 with an alternate solution that has no public API changes, and just makes libnethogs return the same values as ``nethogs``.