### PR TITLE
issue #130 - have Process::gettotal include closed connections removed from ConnList

### DIFF
--- a/src/process.cpp
+++ b/src/process.cpp
@@ -102,6 +102,9 @@ void Process::getkbps(float *recvd, float *sent) {
   ConnList *previous = NULL;
   while (curconn != NULL) {
     if (curconn->getVal()->getLastPacket() <= curtime.tv_sec - CONNTIMEOUT) {
+      /* capture sent and received totals before deleting */
+      this->sent_by_closed_bytes += curconn->getVal()->sumSent;
+      this->rcvd_by_closed_bytes += curconn->getVal()->sumRecv;
       /* stalled connection, remove. */
       ConnList *todelete = curconn;
       Connection *conn_todelete = curconn->getVal();
@@ -137,8 +140,8 @@ void Process::gettotal(u_int32_t *recvd, u_int32_t *sent) {
   }
   // std::cout << "Sum sent: " << sum_sent << std::endl;
   // std::cout << "Sum recv: " << sum_recv << std::endl;
-  *recvd = sum_recv;
-  *sent = sum_sent;
+  *recvd = sum_recv + this->rcvd_by_closed_bytes;
+  *sent = sum_sent + this->sent_by_closed_bytes;
 }
 
 void Process::gettotalmb(float *recvd, float *sent) {

--- a/src/process.h
+++ b/src/process.h
@@ -78,6 +78,8 @@ public:
     connections = NULL;
     pid = 0;
     uid = 0;
+    sent_by_closed_bytes = 0;
+    rcvd_by_closed_bytes = 0;
   }
   void check() { assert(pid >= 0); }
 
@@ -99,6 +101,8 @@ public:
   char *cmdline;
   const char *devicename;
   int pid;
+  u_int32_t sent_by_closed_bytes;
+  u_int32_t rcvd_by_closed_bytes;
 
   ConnList *connections;
   uid_t getUid() { return uid; }


### PR DESCRIPTION
@raboof this implements the method you asked for in your [last comment](https://github.com/raboof/nethogs/issues/130#issuecomment-325127456) on #130 - Process gets internal counters for sent and recd by closed connections, initialized to zero. If getkbps() is called (libnethogs only) and connections are removed from ConnList, their totals are added to the counters. gettotal() returns the sum of the counters for open connections, plus the counters for closed connections. In ``nethogs`` where getkbps() is never called in total mode, there's no change since we're just adding zero. In libnethogs, the result is that Process::gettotal() returns the same thing as it would for ``nethogs``.

This is an alternative to #131 and #132 and the one you asked for. I assume those others can be closed.