### PR TITLE
fixes #129 - libnethogs support for limiting to specific devices

### DIFF
--- a/src/libnethogs.cpp
+++ b/src/libnethogs.cpp
@@ -72,10 +72,10 @@ static bool wait_for_next_trigger() {
   return true;
 }
 
-static int nethogsmonitor_init() {
+static int nethogsmonitor_init(int devc, char **devicenames, bool all) {
   process_init();
 
-  device *devices = get_default_devices();
+  device *devices = get_devices(devc, devicenames, all);
   if (devices == NULL) {
     std::cerr << "No devices to monitor" << std::endl;
     return NETHOGS_STATUS_NO_DEVICE;
@@ -272,11 +272,16 @@ static void nethogsmonitor_clean_up() {
 }
 
 int nethogsmonitor_loop(NethogsMonitorCallback cb) {
+  return nethogsmonitor_loop_devices(cb, 0, NULL, false);
+}
+
+int nethogsmonitor_loop_devices(NethogsMonitorCallback cb,
+                                int devc, char **devicenames, bool all) {
   if (monitor_run_flag) {
     return NETHOGS_STATUS_FAILURE;
   }
 
-  int return_value = nethogsmonitor_init();
+  int return_value = nethogsmonitor_init(devc, devicenames, all);
   if (return_value != NETHOGS_STATUS_OK) {
     return return_value;
   }

--- a/src/libnethogs.h
+++ b/src/libnethogs.h
@@ -58,6 +58,24 @@ typedef void (*NethogsMonitorCallback)(int action,
 NETHOGS_DSO_VISIBLE int nethogsmonitor_loop(NethogsMonitorCallback cb);
 
 /**
+ * @brief Enter the process monitoring loop and reports updates using the
+ * callback provided as parameter. Specify which network devices to monitor.
+ * All parameters other than cb are passed through to get_devices().
+ * This call will block until nethogsmonitor_breakloop() is called or a failure
+ * occurs.
+ * @param cb A pointer to a callback function following the
+ * NethogsMonitorCallback definition
+ * @param devc number of values in devicenames array
+ * @param devicenames pointer to array of devicenames (char arrays)
+ * @param all when false, loopback interface and down/not running interfaces
+ * will be avoided. When true, find all interfaces including down/not running.
+ */
+
+NETHOGS_DSO_VISIBLE int nethogsmonitor_loop_devices(NethogsMonitorCallback cb,
+                                                    int devc, char **devicenames,
+                                                    bool all);
+
+/**
  * @brief Makes the call to nethogsmonitor_loop return.
  */
 NETHOGS_DSO_VISIBLE void nethogsmonitor_breakloop();


### PR DESCRIPTION
This adds support to libnethogs for capturing traffic from only specified devices, like ``nethogs [device [device [device ...]]]``.

The existing libnethogs public API is preserved. In addition to the existing ``int nethogsmonitor_loop(NethogsMonitorCallback cb)`` this adds another method, ``int nethogsmonitor_loop_devices(NethogsMonitorCallback cb, int devc, char **devicenames, bool all)``. This new method allows passing all of the required arguments (devc, devicenames, all) through ``nethogsmonitor_init()`` and on to ``get_devices()``. Instead of using ``get_default_devices()``, we use the ``get_devices()`` function directly.

The existing method, ``nethogsmonitor_loop()`` just calls ``nethogsmonitor_loop_devices()`` with the arguments provided by ``get_default_devices()`` (0, NULL, false) so it ends up making the same call it used to, the arguments are just set at a higher level.

I've also updated and tested ``contrib/python-wrapper.py`` for this.