### PR TITLE
fixes #29 - change all sent/recv counters from int32 to int64 to prevent wraparound

### DIFF
--- a/contrib/python-wrapper.py
+++ b/contrib/python-wrapper.py
@@ -50,8 +50,8 @@ class NethogsMonitorRecord(ctypes.Structure):
                 ('pid', ctypes.c_int),
                 ('uid', ctypes.c_uint32),
                 ('device_name', ctypes.c_char_p),
-                ('sent_bytes', ctypes.c_uint32),
-                ('recv_bytes', ctypes.c_uint32),
+                ('sent_bytes', ctypes.c_uint64),
+                ('recv_bytes', ctypes.c_uint64),
                 ('sent_kbs', ctypes.c_float),
                 ('recv_kbs', ctypes.c_float),
                 )

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -51,8 +51,8 @@ void PackList::add(Packet *p) {
 }
 
 /* sums up the total bytes used and removes 'old' packets */
-u_int32_t PackList::sumanddel(timeval t) {
-  u_int32_t retval = 0;
+u_int64_t PackList::sumanddel(timeval t) {
+  u_int64_t retval = 0;
   PackListNode *current = content;
   PackListNode *previous = NULL;
 
@@ -206,7 +206,7 @@ Connection *findConnection(Packet *packet) {
  * Returns sum of sent packages (by address)
  *	   sum of received packages (by address)
  */
-void Connection::sumanddel(timeval t, u_int32_t *recv, u_int32_t *sent) {
+void Connection::sumanddel(timeval t, u_int64_t *recv, u_int64_t *sent) {
   (*sent) = (*recv) = 0;
 
   *sent = sent_packets->sumanddel(t);

--- a/src/connection.h
+++ b/src/connection.h
@@ -53,7 +53,7 @@ public:
   }
 
   /* sums up the total bytes used and removes 'old' packets */
-  u_int32_t sumanddel(timeval t);
+  u_int64_t sumanddel(timeval t);
 
   /* calling code may delete packet */
   void add(Packet *p);
@@ -83,15 +83,15 @@ public:
 
   /* sums up the total bytes used
    * and removes 'old' packets. */
-  void sumanddel(timeval curtime, u_int32_t *recv, u_int32_t *sent);
+  void sumanddel(timeval curtime, u_int64_t *recv, u_int64_t *sent);
 
   /* for checking if a packet is part of this connection */
   /* the reference packet is always *outgoing*. */
   Packet *refpacket;
 
   /* total sum or sent/received bytes */
-  u_int32_t sumSent;
-  u_int32_t sumRecv;
+  u_int64_t sumSent;
+  u_int64_t sumRecv;
 
 private:
   PackList *sent_packets;

--- a/src/libnethogs.cpp
+++ b/src/libnethogs.cpp
@@ -204,8 +204,8 @@ static void nethogsmonitor_handle_update(NethogsMonitorCallback cb) {
       // continue;
     } else {
       const u_int32_t uid = curproc->getVal()->getUid();
-      u_int32_t sent_bytes;
-      u_int32_t recv_bytes;
+      u_int64_t sent_bytes;
+      u_int64_t recv_bytes;
       float sent_kbs;
       float recv_kbs;
       curproc->getVal()->getkbps(&recv_kbs, &sent_kbs);

--- a/src/libnethogs.h
+++ b/src/libnethogs.h
@@ -24,8 +24,8 @@ typedef struct NethogsMonitorRecord {
   int pid;
   uint32_t uid;
   const char *device_name;
-  uint32_t sent_bytes;
-  uint32_t recv_bytes;
+  uint64_t sent_bytes;
+  uint64_t recv_bytes;
   float sent_kbs;
   float recv_kbs;
 } NethogsMonitorRecord;

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -65,10 +65,10 @@ Process *unknownudp;
 Process *unknownip;
 ProcList *processes;
 
-float tomb(u_int32_t bytes) { return ((double)bytes) / 1024 / 1024; }
-float tokb(u_int32_t bytes) { return ((double)bytes) / 1024; }
+float tomb(u_int64_t bytes) { return ((double)bytes) / 1024 / 1024; }
+float tokb(u_int64_t bytes) { return ((double)bytes) / 1024; }
 
-float tokbps(u_int32_t bytes) { return (((double)bytes) / PERIOD) / 1024; }
+float tokbps(u_int64_t bytes) { return (((double)bytes) / PERIOD) / 1024; }
 
 void process_init() {
   unknowntcp = new Process(0, "", "unknown TCP");
@@ -94,7 +94,7 @@ int Process::getLastPacket() {
 
 /** Get the kb/s values for this process */
 void Process::getkbps(float *recvd, float *sent) {
-  u_int32_t sum_sent = 0, sum_recv = 0;
+  u_int64_t sum_sent = 0, sum_recv = 0;
 
   /* walk though all this process's connections, and sum
    * them up */
@@ -116,7 +116,7 @@ void Process::getkbps(float *recvd, float *sent) {
       delete (todelete);
       delete (conn_todelete);
     } else {
-      u_int32_t sent = 0, recv = 0;
+      u_int64_t sent = 0, recv = 0;
       curconn->getVal()->sumanddel(curtime, &recv, &sent);
       sum_sent += sent;
       sum_recv += recv;
@@ -129,8 +129,8 @@ void Process::getkbps(float *recvd, float *sent) {
 }
 
 /** get total values for this process */
-void Process::gettotal(u_int32_t *recvd, u_int32_t *sent) {
-  u_int32_t sum_sent = 0, sum_recv = 0;
+void Process::gettotal(u_int64_t *recvd, u_int64_t *sent) {
+  u_int64_t sum_sent = 0, sum_recv = 0;
   ConnList *curconn = this->connections;
   while (curconn != NULL) {
     Connection *conn = curconn->getVal();
@@ -145,7 +145,7 @@ void Process::gettotal(u_int32_t *recvd, u_int32_t *sent) {
 }
 
 void Process::gettotalmb(float *recvd, float *sent) {
-  u_int32_t sum_sent = 0, sum_recv = 0;
+  u_int64_t sum_sent = 0, sum_recv = 0;
   gettotal(&sum_recv, &sum_sent);
   *recvd = tomb(sum_recv);
   *sent = tomb(sum_sent);
@@ -153,14 +153,14 @@ void Process::gettotalmb(float *recvd, float *sent) {
 
 /** get total values for this process */
 void Process::gettotalkb(float *recvd, float *sent) {
-  u_int32_t sum_sent = 0, sum_recv = 0;
+  u_int64_t sum_sent = 0, sum_recv = 0;
   gettotal(&sum_recv, &sum_sent);
   *recvd = tokb(sum_recv);
   *sent = tokb(sum_sent);
 }
 
 void Process::gettotalb(float *recvd, float *sent) {
-  u_int32_t sum_sent = 0, sum_recv = 0;
+  u_int64_t sum_sent = 0, sum_recv = 0;
   gettotal(&sum_recv, &sum_sent);
   // std::cout << "Total sent: " << sum_sent << std::endl;
   *sent = sum_sent;

--- a/src/process.h
+++ b/src/process.h
@@ -91,7 +91,7 @@ public:
   }
   int getLastPacket();
 
-  void gettotal(u_int32_t *recvd, u_int32_t *sent);
+  void gettotal(u_int64_t *recvd, u_int64_t *sent);
   void getkbps(float *recvd, float *sent);
   void gettotalmb(float *recvd, float *sent);
   void gettotalkb(float *recvd, float *sent);
@@ -101,8 +101,8 @@ public:
   char *cmdline;
   const char *devicename;
   int pid;
-  u_int32_t sent_by_closed_bytes;
-  u_int32_t rcvd_by_closed_bytes;
+  u_int64_t sent_by_closed_bytes;
+  u_int64_t rcvd_by_closed_bytes;
 
   ConnList *connections;
   uid_t getUid() { return uid; }


### PR DESCRIPTION
This fixes #29 as described in [this comment](https://github.com/raboof/nethogs/issues/29#issuecomment-325127118), by changing all sent/received counters from int32 to int64. This prevents wraparound at ~4GB and will now only wrap at 18.4 Exabytes (which should be a pretty rare occurrence).

I confirmed the current wraparound behavior by scp'ing a 7G file from my desktop to another machine on my LAN. Sure enough, with current master ( e545524 ) running `nethogs -v 3` (total MB mode) the sent counter wraps around somewhere around 4,000 MB:

![master](https://user-images.githubusercontent.com/273454/29750782-1be713d4-8b14-11e7-913a-f8cdad3718e0.png)

Using this branch, the counters properly reflect the full transfer amount:

![fixed](https://user-images.githubusercontent.com/273454/29750788-2d10024c-8b14-11e7-8cc3-0acd8b78a4bf.png)

The fix is also verified with the python-wrapper/libnethogs.