### PR TITLE
issue #144 - handle empty /proc/<pid>/cmdline properly in getcmdline()

### DIFF
--- a/src/inode2prog.cpp
+++ b/src/inode2prog.cpp
@@ -125,6 +125,12 @@ std::string getcmdline(pid_t pid) {
   bool replace_null = false;
   std::string cmdline = read_file(filename);
 
+  if (cmdline.empty() || cmdline[cmdline.length() - 1] != '\0') {
+    // invalid content of cmdline file. Add null char to allow further
+    // processing.
+    cmdline.append(1, '\0');
+  }
+
   // join parameters, keep prgname separate, don't overwrite trailing null
   for (size_t idx = 0; idx < (cmdline.length() - 1); idx++) {
     if (cmdline[idx] == 0x00) {
@@ -133,12 +139,6 @@ std::string getcmdline(pid_t pid) {
       }
       replace_null = true;
     }
-  }
-
-  if (cmdline.length() == 0 || (cmdline[cmdline.length() - 1] != 0x00)) {
-    // invalid content of cmdline file. Add null char to allow further
-    // processing.
-    cmdline.append("\0");
   }
 
   return cmdline;


### PR DESCRIPTION
Append a '\0' for empty cmdline to avoid underflow of cmdline.length() - 1.
Also note that `cmdline.append("\0")` is a no-op.