### PR TITLE
Fix libnethogs handle memory leak

### DIFF
--- a/src/libnethogs.cpp
+++ b/src/libnethogs.cpp
@@ -259,10 +259,14 @@ static void nethogsmonitor_handle_update(NethogsMonitorCallback cb) {
 static void nethogsmonitor_clean_up() {
   // clean up
   handle *current_handle = handles;
+  handle *rem;
   while (current_handle != NULL) {
     pcap_close(current_handle->content->pcap_handle);
+    rem = current_handle;
     current_handle = current_handle->next;
+    free(rem);
   }
+  handles = NULL;
 
   // close file descriptors
   for (std::vector<int>::const_iterator it = pc_loop_fd_list.begin();


### PR DESCRIPTION
Calling nethogsmonitor_loop, canceling it with nethogsmonitor_breakloop
and then calling it again will lead to a Segmentation fault.

This is due to handles not getting reset to NULL which leads to a
invalid list since the old list will be reused by

  new handle(newhandle, current_dev->name, handles);

in nethogsmonitor_init(). If handles is reset to NULL it will also
remove the only reference to the old list, hence it should be freed to
avoid memory leaks.

This change will reset handles to NULL after freeing all handles when
nethogsmonitor_clean_up is called.