### PR TITLE
Escape asterisk

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Nethogs depends on `ncurses` for the text-based interface and `libpcap` for user
 
 #### Yum-based distro's
 
-    yum install gcc-c++ libpcap-devel.x86_64 libpcap.x86_64 ncurses*
+    yum install gcc-c++ libpcap-devel.x86_64 libpcap.x86_64 ncurses\*
 
 #### Getting the source
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Nethogs depends on `ncurses` for the text-based interface and `libpcap` for user
 
 #### Yum-based distro's
 
-    yum install gcc-c++ libpcap-devel.x86_64 libpcap.x86_64 ncurses\*
+    yum install gcc-c++ libpcap-devel.x86_64 libpcap.x86_64 "ncurses*"
 
 #### Getting the source
 


### PR DESCRIPTION
In order for the glob to properly expand, it needs to be escaped.