### PR TITLE
fixes crash on "opening /proc/PID/cmdline" #144,#145

### DIFF
--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -20,8 +20,8 @@
  *
  */
 
-#include <iostream>
 #include <cassert>
+#include <iostream>
 #ifdef __APPLE__
 #include <sys/malloc.h>
 #elif __FreeBSD__
@@ -29,8 +29,8 @@
 #else
 #include <malloc.h>
 #endif
-#include "nethogs.h"
 #include "connection.h"
+#include "nethogs.h"
 #include "process.h"
 
 ConnList *connections = NULL;
@@ -152,24 +152,21 @@ void Connection::add(Packet *packet) {
   }
 }
 
-Connection *findConnectionWithMatchingSource(Packet *packet, short int packettype) {
+Connection *findConnectionWithMatchingSource(Packet *packet,
+                                             short int packettype) {
   assert(packet->Outgoing());
 
   ConnList *current = NULL;
-  switch(packettype)
-  {
-    case IPPROTO_TCP:
-      {
-          current = connections;
-          break;
-      }
+  switch (packettype) {
+  case IPPROTO_TCP: {
+    current = connections;
+    break;
+  }
 
-    case IPPROTO_UDP:
-      {
-          current = unknownudp->connections;
-          break;
-      }
-
+  case IPPROTO_UDP: {
+    current = unknownudp->connections;
+    break;
+  }
   }
 
   while (current != NULL) {
@@ -180,28 +177,24 @@ Connection *findConnectionWithMatchingSource(Packet *packet, short int packettyp
 
     current = current->getNext();
   }
-  
+
   return NULL;
-  
 }
 
-Connection *findConnectionWithMatchingRefpacketOrSource(Packet *packet, short int packettype) {
-  
-  ConnList *current = NULL;
-  switch(packettype)
-  {
-    case IPPROTO_TCP:
-      {  
-        current = connections;
-        break;
-      }
+Connection *findConnectionWithMatchingRefpacketOrSource(Packet *packet,
+                                                        short int packettype) {
 
-    case IPPROTO_UDP:
-      {  
-          current = unknownudp->connections;
-          break;
-        
-      }
+  ConnList *current = NULL;
+  switch (packettype) {
+  case IPPROTO_TCP: {
+    current = connections;
+    break;
+  }
+
+  case IPPROTO_UDP: {
+    current = unknownudp->connections;
+    break;
+  }
   }
 
   while (current != NULL) {

--- a/src/connection.h
+++ b/src/connection.h
@@ -22,8 +22,8 @@
 #ifndef __CONNECTION_H
 #define __CONNECTION_H
 
-#include <iostream>
 #include "packet.h"
+#include <iostream>
 
 class PackListNode {
 public:

--- a/src/conninode.cpp
+++ b/src/conninode.cpp
@@ -20,13 +20,13 @@
  *
  */
 
-#include <netinet/in.h>
-#include <map>
 #include <cstdio>
+#include <map>
+#include <netinet/in.h>
 #include <stdlib.h>
 
-#include "nethogs.h"
 #include "conninode.h"
+#include "nethogs.h"
 
 #if defined(__APPLE__) || defined(__FreeBSD__)
 #ifndef s6_addr32
@@ -73,8 +73,9 @@ void addtoconninode(char *buffer) {
   }
   unsigned long inode;
 
-  int matches = sscanf(buffer, "%*d: %64[0-9A-Fa-f]:%X %64[0-9A-Fa-f]:%X %*X "
-                               "%*X:%*X %*X:%*X %*X %*d %*d %ld %*512s\n",
+  int matches = sscanf(buffer,
+                       "%*d: %64[0-9A-Fa-f]:%X %64[0-9A-Fa-f]:%X %*X "
+                       "%*X:%*X %*X:%*X %*X %*d %*d %ld %*512s\n",
                        local_addr, &local_port, rem_addr, &rem_port, &inode);
 
   if (matches != 5) {
@@ -102,7 +103,7 @@ void addtoconninode(char *buffer) {
     if ((in6_local.s6_addr32[0] == 0x0) && (in6_local.s6_addr32[1] == 0x0) &&
         (in6_local.s6_addr32[2] == 0xFFFF0000)) {
       /* IPv4-compatible address */
-      result_addr_local.s6_addr32[0]  = in6_local.s6_addr32[3];
+      result_addr_local.s6_addr32[0] = in6_local.s6_addr32[3];
       result_addr_remote.s6_addr32[0] = in6_remote.s6_addr32[3];
       sa_family = AF_INET;
     } else {
@@ -179,9 +180,9 @@ int addprocinfo(const char *filename) {
 }
 
 void refreshconninode() {
-/* we don't forget old mappings, just overwrite */
-// delete conninode;
-// conninode = new HashTable (256);
+  /* we don't forget old mappings, just overwrite */
+  // delete conninode;
+  // conninode = new HashTable (256);
 
 #if defined(__APPLE__) || defined(__FreeBSD__)
   addprocinfo("net.inet.tcp.pcblist");

--- a/src/cui.cpp
+++ b/src/cui.cpp
@@ -21,17 +21,16 @@
  */
 
 /* NetHogs console UI */
-#include <string>
-#include <pwd.h>
-#include <sys/types.h>
-#include <cstdlib>
+#include <algorithm>
 #include <cerrno>
 #include <cstdlib>
-#include <algorithm>
+#include <pwd.h>
+#include <string>
+#include <sys/types.h>
 
-#include <ncurses.h>
 #include "nethogs.h"
 #include "process.h"
+#include <ncurses.h>
 
 std::string *caption;
 extern const char version[];
@@ -65,7 +64,8 @@ const char *COLUMN_FORMAT_SENT = "%11.3f";
 const char *COLUMN_FORMAT_RECEIVED = "%11.3f";
 
 // All descriptions are padded to 6 characters in length with spaces
-const char* const desc_view_mode[VIEWMODE_COUNT] = {"KB/sec", "KB    ", "B     ", "MB    ", "MB/sec", "GB/sec"};
+const char *const desc_view_mode[VIEWMODE_COUNT] = {
+    "KB/sec", "KB    ", "B     ", "MB    ", "MB/sec", "GB/sec"};
 
 class Line {
 public:
@@ -217,27 +217,26 @@ void Line::log() {
   std::cout << m_name;
   if (showcommandline && m_cmdline)
     std::cout << ' ' << m_cmdline;
-  std::cout << '/' << m_pid << '/' << m_uid << "\t" << sent_value << "\t" << recv_value << std::endl;
+  std::cout << '/' << m_pid << '/' << m_uid << "\t" << sent_value << "\t"
+            << recv_value << std::endl;
 }
 
-int get_devlen(Line *lines[], int nproc, int rows)
-{
-  int devlen = MIN_COLUMN_WIDTH_DEV; int curlen;
+int get_devlen(Line *lines[], int nproc, int rows) {
+  int devlen = MIN_COLUMN_WIDTH_DEV;
+  int curlen;
   for (int i = 0; i < nproc; i++) {
-    if (i + 3 < rows)
-	{
-		curlen = strlen(lines[i]->devicename);
-		if(curlen > devlen)
-			curlen = devlen;
-	}
- }
+    if (i + 3 < rows) {
+      curlen = strlen(lines[i]->devicename);
+      if (curlen > devlen)
+        curlen = devlen;
+    }
+  }
 
- if(devlen > MAX_COLUMN_WIDTH_DEV)
-	devlen = MAX_COLUMN_WIDTH_DEV;
+  if (devlen > MAX_COLUMN_WIDTH_DEV)
+    devlen = MAX_COLUMN_WIDTH_DEV;
 
- return devlen;
+  return devlen;
 }
-
 
 int GreatestFirst(const void *ma, const void *mb) {
   Line **pa = (Line **)ma;
@@ -349,9 +348,8 @@ void show_ncurses(Line *lines[], int nproc) {
   if (cols > PROGNAME_WIDTH)
     cols = PROGNAME_WIDTH;
 
-
- //issue #110 - maximum devicename length min=5, max=15
- int devlen = get_devlen(lines, nproc, rows);
+  // issue #110 - maximum devicename length min=5, max=15
+  int devlen = get_devlen(lines, nproc, rows);
 
   proglen = cols - 50 - devlen;
 
@@ -360,14 +358,14 @@ void show_ncurses(Line *lines[], int nproc) {
   attron(A_REVERSE);
   mvprintw(2, 0,
            "    PID USER     %-*.*s  %-*.*s       SENT      RECEIVED       ",
-           proglen, proglen, "PROGRAM",devlen,devlen,"DEV");
+           proglen, proglen, "PROGRAM", devlen, devlen, "DEV");
   attroff(A_REVERSE);
 
   /* print them */
   int i;
   for (i = 0; i < nproc; i++) {
     if (i + 3 < rows)
-      lines[i]->show(i + 3, proglen,devlen);
+      lines[i]->show(i + 3, proglen, devlen);
     recv_global += lines[i]->recv_value;
     sent_global += lines[i]->sent_value;
     delete lines[i];
@@ -375,7 +373,7 @@ void show_ncurses(Line *lines[], int nproc) {
   attron(A_REVERSE);
   int totalrow = std::min(rows - 1, 3 + 1 + i);
   mvprintw(totalrow, 0, "  TOTAL        %-*.*s %-*.*s    %11.3f %11.3f ",
-           proglen, proglen, "", devlen,devlen, "", sent_global, recv_global);
+           proglen, proglen, "", devlen, devlen, "", sent_global, recv_global);
   mvprintw(3 + 1 + i, cols - COLUMN_WIDTH_UNIT, desc_view_mode[viewMode]);
   attroff(A_REVERSE);
   mvprintw(totalrow + 1, 0, "");
@@ -387,7 +385,8 @@ void do_refresh() {
   refreshconninode();
   refreshcount++;
 
-  if (viewMode == VIEWMODE_KBPS  || viewMode == VIEWMODE_MBPS || viewMode == VIEWMODE_GBPS) {
+  if (viewMode == VIEWMODE_KBPS || viewMode == VIEWMODE_MBPS ||
+      viewMode == VIEWMODE_GBPS) {
     remove_timed_out_processes();
   }
 

--- a/src/decpcap.c
+++ b/src/decpcap.c
@@ -20,16 +20,16 @@
  *
  */
 
-#include <sys/types.h>
+#include "decpcap.h"
 #include <net/ethernet.h>
 #include <net/if.h>
 #include <netinet/in.h>
 #include <netinet/ip.h>
 #include <netinet/ip6.h>
 #include <netinet/tcp.h>
-#include <string.h> // for memcpy
 #include <pcap.h>
-#include "decpcap.h"
+#include <string.h> // for memcpy
+#include <sys/types.h>
 
 #define DP_DEBUG 0
 bool catchall = false;
@@ -79,8 +79,8 @@ struct dp_handle *dp_open_offline(char *fname, char *ebuf) {
 struct dp_handle *dp_open_live(const char *device, int snaplen, int promisc,
                                int to_ms, char *filter, char *errbuf) {
   struct bpf_program fp; // compiled filter program
-  bpf_u_int32 maskp; // subnet mask
-  bpf_u_int32 netp; // interface IP
+  bpf_u_int32 maskp;     // subnet mask
+  bpf_u_int32 netp;      // interface IP
 
   pcap_t *temp = pcap_open_live(device, snaplen, promisc, to_ms, errbuf);
 
@@ -92,25 +92,19 @@ struct dp_handle *dp_open_live(const char *device, int snaplen, int promisc,
     pcap_lookupnet(device, &netp, &maskp, errbuf);
 
     /* Compile the filter */
-    if(pcap_compile(temp, &fp, filter, 1, netp) == -1) {
-      fprintf(
-        stderr,
-        "Error calling pcap_compile for filter on device %s: %s\n",
-        device, pcap_geterr(temp)
-      );
+    if (pcap_compile(temp, &fp, filter, 1, netp) == -1) {
+      fprintf(stderr,
+              "Error calling pcap_compile for filter on device %s: %s\n",
+              device, pcap_geterr(temp));
       return NULL;
     }
 
     /* set the filter */
-    if(pcap_setfilter(temp, &fp) == -1) {
-      fprintf(
-        stderr,
-        "Error setting capture filter on device %s: %s\n",
-        device, pcap_geterr(temp)
-      );
+    if (pcap_setfilter(temp, &fp) == -1) {
+      fprintf(stderr, "Error setting capture filter on device %s: %s\n", device,
+              pcap_geterr(temp));
       return NULL;
     }
-
   }
 
   return dp_fillhandle(temp);
@@ -170,7 +164,7 @@ void dp_parse_ip(struct dp_handle *handle, const dp_header *header,
     dp_parse_tcp(handle, header, payload);
     break;
   case IPPROTO_UDP:
-    if(catchall)
+    if (catchall)
       dp_parse_udp(handle, header, payload);
     break;
   default:
@@ -195,7 +189,7 @@ void dp_parse_ip6(struct dp_handle *handle, const dp_header *header,
     dp_parse_tcp(handle, header, payload);
     break;
   case IPPROTO_UDP:
-    if(catchall)
+    if (catchall)
       dp_parse_udp(handle, header, payload);
     break;
   default:

--- a/src/decpcap.h
+++ b/src/decpcap.h
@@ -22,10 +22,10 @@
 #ifndef __DECPCAP_H
 #define __DECPCAP_H
 
-#include <stdlib.h>
-#include <stdio.h>
 #include <pcap.h>
 #include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
 
 #define DP_ERRBUF_SIZE PCAP_ERRBUF_SIZE
 extern bool catchall;

--- a/src/devices.cpp
+++ b/src/devices.cpp
@@ -22,12 +22,12 @@
 
 #include "devices.h"
 
-#include <iostream>
 #include <cstring>
+#include <iostream>
 
-#include <sys/socket.h>
-#include <net/if.h>
 #include <ifaddrs.h>
+#include <net/if.h>
+#include <sys/socket.h>
 
 bool selected(int devc, char **devicenames, char *devicename) {
   if (devc == 0)

--- a/src/inode2prog.cpp
+++ b/src/inode2prog.cpp
@@ -121,9 +121,21 @@ std::string getcmdline(pid_t pid) {
   char filename[maxfilenamelen];
 
   std::snprintf(filename, maxfilenamelen, "/proc/%d/cmdline", pid);
-
+  std::string cmdline;
   bool replace_null = false;
-  std::string cmdline = read_file(filename);
+  try {
+   cmdline = read_file(filename);
+  } catch (int e) {
+      std::fprintf(stderr, "An exception occurred. Exception Nr %i \n", e);
+      cmdline = "";
+  }
+
+  if (cmdline.empty() || cmdline[cmdline.length() - 1] != '\0') {
+    // invalid content of cmdline file. Add null char to allow further
+    // processing.
+    cmdline.append(1, '\0');
+    return cmdline;
+  }
 
   // join parameters, keep prgname separate, don't overwrite trailing null
   for (size_t idx = 0; idx < (cmdline.length() - 1); idx++) {
@@ -134,13 +146,6 @@ std::string getcmdline(pid_t pid) {
       replace_null = true;
     }
   }
-
-  if (cmdline.length() == 0 || (cmdline[cmdline.length() - 1] != 0x00)) {
-    // invalid content of cmdline file. Add null char to allow further
-    // processing.
-    cmdline.append("\0");
-  }
-
   return cmdline;
 }
 

--- a/src/inode2prog.cpp
+++ b/src/inode2prog.cpp
@@ -20,20 +20,20 @@
  *
  */
 
-#include <sys/types.h>
 #include <cerrno>
-#include <cstring>
-#include <dirent.h>
-#include <ctype.h>
-#include <cstdlib>
-#include <iostream>
-#include <cstdio>
-#include <unistd.h>
-#include <string>
-#include <map>
-#include <sys/stat.h>
-#include <fcntl.h>
 #include <climits>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctype.h>
+#include <dirent.h>
+#include <fcntl.h>
+#include <iostream>
+#include <map>
+#include <string>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 
 #include "inode2prog.h"
 
@@ -124,10 +124,10 @@ std::string getcmdline(pid_t pid) {
   std::string cmdline;
   bool replace_null = false;
   try {
-   cmdline = read_file(filename);
+    cmdline = read_file(filename);
   } catch (int e) {
-      std::fprintf(stderr, "An exception occurred. Exception Nr %i \n", e);
-      cmdline = "";
+    std::fprintf(stderr, "An exception occurred. Exception Nr %i \n", e);
+    cmdline = "";
   }
 
   if (cmdline.empty() || cmdline[cmdline.length() - 1] != '\0') {

--- a/src/libnethogs.cpp
+++ b/src/libnethogs.cpp
@@ -3,13 +3,13 @@ extern "C" {
 }
 
 #include "nethogs.cpp"
-#include <iostream>
-#include <memory>
-#include <map>
-#include <vector>
 #include <cstring>
-#include <fcntl.h>
 #include <errno.h>
+#include <fcntl.h>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <vector>
 
 //////////////////////////////
 extern ProcList *processes;
@@ -72,8 +72,8 @@ static bool wait_for_next_trigger() {
   return true;
 }
 
-static int nethogsmonitor_init(int devc, char **devicenames,
-                               bool all, char *filter) {
+static int nethogsmonitor_init(int devc, char **devicenames, bool all,
+                               char *filter) {
   process_init();
 
   device *devices = get_devices(devc, devicenames, all);
@@ -100,9 +100,8 @@ static int nethogsmonitor_init(int devc, char **devicenames,
     }
 
     char errbuf[PCAP_ERRBUF_SIZE];
-    dp_handle *newhandle =
-        dp_open_live(current_dev->name, BUFSIZ, promiscuous,
-                     100, filter, errbuf);
+    dp_handle *newhandle = dp_open_live(current_dev->name, BUFSIZ, promiscuous,
+                                        100, filter, errbuf);
     if (newhandle != NULL) {
       dp_addcb(newhandle, dp_packet_ip, process_ip);
       dp_addcb(newhandle, dp_packet_ip6, process_ip6);

--- a/src/libnethogs.h
+++ b/src/libnethogs.h
@@ -5,8 +5,8 @@
 extern "C" {
 #endif
 
-#include <stdint.h>
 #include <stdbool.h>
+#include <stdint.h>
 
 #define NETHOGS_DSO_VISIBLE __attribute__((visibility("default")))
 #define NETHOGS_DSO_HIDDEN __attribute__((visibility("hidden")))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,11 +3,11 @@
 #include <vector>
 
 #ifdef __linux__
+#include <linux/capability.h>
 #include <linux/limits.h>
-#include <unistd.h>
 #include <sys/types.h>
 #include <sys/xattr.h>
-#include <linux/capability.h>
+#include <unistd.h>
 #endif
 
 // The self_pipe is used to interrupt the select() in the main loop
@@ -43,9 +43,11 @@ static void help(bool iserror) {
   output << "		-p : sniff in promiscious mode (not recommended).\n";
   output << "		-s : sort output by sent column.\n";
   output << "		-l : display command line.\n";
-  output << "		-a : monitor all devices, even loopback/stopped ones.\n";
+  output << "		-a : monitor all devices, even loopback/stopped "
+            "ones.\n";
   output << "		-C : capture TCP and UDP.\n";
-  output << "		-f : EXPERIMENTAL: specify string pcap filter (like tcpdump)."
+  output << "		-f : EXPERIMENTAL: specify string pcap filter (like "
+            "tcpdump)."
             " This may be removed or changed in a future version.\n";
   output << "		device : device(s) to monitor. default is all "
             "interfaces up and running excluding loopback\n";
@@ -55,7 +57,8 @@ static void help(bool iserror) {
   output << " s: sort by SENT traffic\n";
   output << " r: sort by RECEIVE traffic\n";
   output << " l: display command line\n";
-  output << " m: switch between total (KB, B, MB) and throughput (KB/s, MB/s, GB/s) mode\n";
+  output << " m: switch between total (KB, B, MB) and throughput (KB/s, MB/s, "
+            "GB/s) mode\n";
 }
 
 void quit_cb(int /* i */) {
@@ -161,7 +164,7 @@ int main(int argc, char **argv) {
       sortRecv = false;
       break;
     case 'd':
-      refreshdelay = (time_t) atoi(optarg);
+      refreshdelay = (time_t)atoi(optarg);
       break;
     case 'v':
       viewMode = atoi(optarg) % VIEWMODE_COUNT;
@@ -201,7 +204,7 @@ int main(int argc, char **argv) {
 #ifdef __linux__
     char exe_path[PATH_MAX];
     ssize_t len;
-    unsigned int caps[5] = {0,0,0,0,0};
+    unsigned int caps[5] = {0, 0, 0, 0, 0};
 
     if ((len = readlink("/proc/self/exe", exe_path, PATH_MAX)) == -1)
       forceExit(false, "Failed to locate nethogs binary.");
@@ -209,8 +212,11 @@ int main(int argc, char **argv) {
 
     getxattr(exe_path, "security.capability", (char *)caps, sizeof(caps));
 
-    if ((((caps[1] >> CAP_NET_ADMIN) & 1) != 1) || (((caps[1] >> CAP_NET_RAW) & 1) != 1))
-      forceExit(false, "To run nethogs without being root you need to enable capabilities on the program (cap_net_admin, cap_net_raw), see the documentation for details.");
+    if ((((caps[1] >> CAP_NET_ADMIN) & 1) != 1) ||
+        (((caps[1] >> CAP_NET_RAW) & 1) != 1))
+      forceExit(false, "To run nethogs without being root you need to enable "
+                       "capabilities on the program (cap_net_admin, "
+                       "cap_net_raw), see the documentation for details.");
 #else
     forceExit(false, "You need to be root to run NetHogs!");
 #endif
@@ -298,11 +304,12 @@ int main(int argc, char **argv) {
       int retval = dp_dispatch(current_handle->content, -1, (u_char *)userdata,
                                sizeof(struct dpargs));
       if (retval == -1)
-        std::cerr << "Error dispatching for device " << current_handle->devicename <<
-          ": " << dp_geterr(current_handle->content) << std::endl;
+        std::cerr << "Error dispatching for device "
+                  << current_handle->devicename << ": "
+                  << dp_geterr(current_handle->content) << std::endl;
       else if (retval < 0)
-        std::cerr << "Error dispatching for device " << current_handle->devicename <<
-          ": " << retval << std::endl;
+        std::cerr << "Error dispatching for device "
+                  << current_handle->devicename << ": " << retval << std::endl;
       else if (retval != 0)
         packets_read = true;
     }

--- a/src/nethogs.cpp
+++ b/src/nethogs.cpp
@@ -22,16 +22,16 @@
 
 #include "nethogs.h"
 
-#include <iostream>
+#include <cassert>
+#include <csignal>
+#include <cstdarg>
 #include <cstdio>
 #include <cstdlib>
-#include <cassert>
-#include <unistd.h>
-#include <csignal>
-#include <string>
 #include <cstring>
 #include <getopt.h>
-#include <cstdarg>
+#include <iostream>
+#include <string>
+#include <unistd.h>
 
 #include <netinet/ip.h>
 #include <netinet/ip6.h>
@@ -44,10 +44,10 @@ extern "C" {
 #include "decpcap.h"
 }
 
-#include "packet.h"
 #include "connection.h"
-#include "process.h"
 #include "devices.h"
+#include "packet.h"
+#include "process.h"
 
 extern Process *unknownudp;
 
@@ -203,7 +203,7 @@ int process_udp(u_char *userdata, const dp_header *header,
     /* else: unknown connection, create new */
     connection = new Connection(packet);
     unknownudp->connections = new ConnList(connection, unknownudp->connections);
-    //getProcess(connection, args->device);
+    // getProcess(connection, args->device);
   }
   delete packet;
 

--- a/src/nethogs.h
+++ b/src/nethogs.h
@@ -23,12 +23,12 @@
 #ifndef __NETHOGS_H
 #define __NETHOGS_H
 
-#include <netinet/in.h>
-#include <sys/types.h>
-#include <sys/socket.h>
 #include <arpa/inet.h>
 #include <cassert>
 #include <cstring>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <sys/types.h>
 #ifdef __APPLE__
 #include <sys/malloc.h>
 #elif __FreeBSD__

--- a/src/packet.cpp
+++ b/src/packet.cpp
@@ -20,12 +20,12 @@
  *
  */
 
+#include "packet.h"
 #include "nethogs.h"
 #include <iostream>
-#include "packet.h"
-#include <stdio.h>
-#include <netinet/tcp.h>
 #include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <stdio.h>
 #ifdef __APPLE__
 #include <sys/malloc.h>
 #elif __FreeBSD__
@@ -34,12 +34,12 @@
 #include <malloc.h>
 #endif
 #include <cassert>
-#include <net/if.h>
+#include <ifaddrs.h>
 #include <net/ethernet.h>
+#include <net/if.h>
 #include <netinet/ip.h>
 #include <netinet/ip6.h>
 #include <sys/ioctl.h>
-#include <ifaddrs.h>
 // #include "inet6.c"
 
 local_addr *local_addrs = NULL;

--- a/src/packet.h
+++ b/src/packet.h
@@ -26,10 +26,10 @@
 #define _BSD_SOURCE 1
 #include <net/ethernet.h>
 
-#include <sys/socket.h>
-#include <netinet/in.h>
-#include <arpa/inet.h>
 #include "nethogs.h"
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
 
 enum direction { dir_unknown, dir_incoming, dir_outgoing };
 

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -21,24 +21,24 @@
  */
 
 #include <iostream>
-#include <strings.h>
-#include <string>
 #include <ncurses.h>
+#include <string>
+#include <strings.h>
 #if !defined(__APPLE__) && !defined(__FreeBSD__)
 #include <asm/types.h>
 #endif
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <unistd.h>
-#include <sys/socket.h>
-#include <stdlib.h>
-#include <pwd.h>
 #include <map>
+#include <pwd.h>
+#include <stdlib.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 
-#include "process.h"
-#include "nethogs.h"
-#include "inode2prog.h"
 #include "conninode.h"
+#include "inode2prog.h"
+#include "nethogs.h"
+#include "process.h"
 
 extern timeval curtime;
 extern bool catchall;
@@ -80,10 +80,9 @@ void process_init() {
   unknowntcp = new Process(0, "", "unknown TCP");
   processes = new ProcList(unknowntcp, NULL);
 
-  if(catchall)
-  {
-    unknownudp = new Process (0, "", "unknown UDP");
-    processes = new ProcList (unknownudp, processes);
+  if (catchall) {
+    unknownudp = new Process(0, "", "unknown UDP");
+    processes = new ProcList(unknownudp, processes);
     // unknownip = new Process (0, "", "unknown IP");
     // processes = new ProcList (unknownip, processes);
   }
@@ -103,7 +102,8 @@ int Process::getLastPacket() {
 }
 
 /** get total values for this process for only active connections */
-static void sum_active_connections(Process* process_ptr, u_int64_t& sum_sent, u_int64_t& sum_recv) {
+static void sum_active_connections(Process *process_ptr, u_int64_t &sum_sent,
+                                   u_int64_t &sum_recv) {
   /* walk though all process_ptr process's connections, and sum
    * them up */
   ConnList *curconn = process_ptr->connections;
@@ -313,8 +313,8 @@ Process *getProcess(Connection *connection, const char *devicename) {
     // no? refresh and check conn/inode table
     if (bughuntmode) {
       std::cout << "?  new connection not in connection-to-inode table before "
-                   "refresh, hash " << connection->refpacket->gethashstring()
-                << std::endl;
+                   "refresh, hash "
+                << connection->refpacket->gethashstring() << std::endl;
     }
 // refresh the inode->pid table first. Presumably processing the renewed
 // connection->inode table
@@ -390,7 +390,8 @@ void procclean() {
 void remove_timed_out_processes() {
   ProcList *previousproc = NULL;
 
-  for (ProcList *curproc = processes; curproc != NULL; curproc = curproc->next) {
+  for (ProcList *curproc = processes; curproc != NULL;
+       curproc = curproc->next) {
     if ((curproc->getVal()->getLastPacket() + PROCESSTIMEOUT <=
          curtime.tv_sec) &&
         (curproc->getVal() != unknowntcp) &&

--- a/src/process.h
+++ b/src/process.h
@@ -23,9 +23,9 @@
 #ifndef __PROCESS_H
 #define __PROCESS_H
 
-#include <cassert>
-#include "nethogs.h"
 #include "connection.h"
+#include "nethogs.h"
+#include <cassert>
 
 extern bool tracemode;
 extern bool bughuntmode;


### PR DESCRIPTION
* adds try catch in inode2prog.cpp to the around the read_file call in the function getcmdline.
  This fixes the crashes which are occurring if the PID file is removed while trying to read them.
  These problems are described in #144 and #145 
* reformats the repo with clang-format as was described in the readme file 