### PR TITLE
fix: Expose to_ms / packet buffer timeout to libnethogs

### DIFF
--- a/src/libnethogs.cpp
+++ b/src/libnethogs.cpp
@@ -73,7 +73,7 @@ static bool wait_for_next_trigger() {
 }
 
 static int nethogsmonitor_init(int devc, char **devicenames, bool all,
-                               char *filter) {
+                               char *filter, int to_ms) {
   process_init();
 
   device *devices = get_devices(devc, devicenames, all);
@@ -101,7 +101,7 @@ static int nethogsmonitor_init(int devc, char **devicenames, bool all,
 
     char errbuf[PCAP_ERRBUF_SIZE];
     dp_handle *newhandle = dp_open_live(current_dev->name, BUFSIZ, promiscuous,
-                                        100, filter, errbuf);
+                                        to_ms, filter, errbuf);
     if (newhandle != NULL) {
       dp_addcb(newhandle, dp_packet_ip, process_ip);
       dp_addcb(newhandle, dp_packet_ip6, process_ip6);
@@ -276,17 +276,17 @@ static void nethogsmonitor_clean_up() {
   procclean();
 }
 
-int nethogsmonitor_loop(NethogsMonitorCallback cb, char *filter) {
-  return nethogsmonitor_loop_devices(cb, filter, 0, NULL, false);
+int nethogsmonitor_loop(NethogsMonitorCallback cb, char *filter, int to_ms) {
+    return nethogsmonitor_loop_devices(cb, filter, 0, NULL, false, to_ms);
 }
 
 int nethogsmonitor_loop_devices(NethogsMonitorCallback cb, char *filter,
-                                int devc, char **devicenames, bool all) {
+                                int devc, char **devicenames, bool all, int to_ms) {
   if (monitor_run_flag) {
     return NETHOGS_STATUS_FAILURE;
   }
 
-  int return_value = nethogsmonitor_init(devc, devicenames, all, filter);
+  int return_value = nethogsmonitor_init(devc, devicenames, all, filter, to_ms);
   if (return_value != NETHOGS_STATUS_OK) {
     return return_value;
   }

--- a/src/libnethogs.h
+++ b/src/libnethogs.h
@@ -58,10 +58,12 @@ typedef void (*NethogsMonitorCallback)(int action,
  * that of tcpdump(1); for full details, see the man page for pcap-filter(7).
  * Note that this is EXPERIMENTAL, and may be removed or changed in a future
  * version.
+ * @param to_ms: <insert documentation>
  */
 
 NETHOGS_DSO_VISIBLE int nethogsmonitor_loop(NethogsMonitorCallback cb,
-                                            char *filter);
+                                            char *filter,
+                                            int to_ms);
 
 /**
  * @brief Enter the process monitoring loop and reports updates using the
@@ -85,7 +87,8 @@ NETHOGS_DSO_VISIBLE int nethogsmonitor_loop(NethogsMonitorCallback cb,
 NETHOGS_DSO_VISIBLE int nethogsmonitor_loop_devices(NethogsMonitorCallback cb,
                                                     char *filter, int devc,
                                                     char **devicenames,
-                                                    bool all);
+                                                    bool all,
+                                                    int to_ms);
 
 /**
  * @brief Makes the call to nethogsmonitor_loop return.


### PR DESCRIPTION
* Exposes the underlying https://www.tcpdump.org/manpages/pcap.3pcap.html option `to_ms` which allows to control the packet buffer timeout when collecting packets.
* 100ms is too short or some applications and leads to high CPU usage. Arguably, in some applications 100ms is "irrelevant" if the connection is not active for longer than 100ms, as the amount of data transferred will be very low.
* I'm aware of discussions where values of 3000+ms leads to being unable to track certain connections.