### PR TITLE
Issue: #96 - Garbage collect inodeproc on each ui refresh.

### DIFF
--- a/doc/nethogs.8
+++ b/doc/nethogs.8
@@ -19,6 +19,7 @@ nethogs \- Net top tool grouping bandwidth per process
 .RB [ "\-l" ]
 .RB [ "\-f filter" ]
 .RB [ "\-C" ]
+.RB [ "\-g period" ]
 .RI [device(s)]
 .SH DESCRIPTION
 NetHogs is a small 'net top' tool. Instead of breaking the traffic down per protocol or per subnet, like most such tools do, it groups bandwidth by process - and does not rely on a special kernel module to be loaded. So if there's suddenly a lot of network traffic, you can fire up NetHogs and immediately see which PID is causing this, and if it's some kind of spinning process, kill it.
@@ -60,6 +61,9 @@ monitor all devices, even loopback/stopped ones.
 .TP
 \fB-C\fP
 capture TCP and UDP.
+.TP
+\fB-g\fP
+garbage collection period in number of refresh. default is 50.
 .TP
 \fB-f\fP
 EXPERIMENTAL: specify string pcap filter (like tcpdump). This may be removed or changed in a future version.

--- a/src/inode2prog.cpp
+++ b/src/inode2prog.cpp
@@ -235,8 +235,7 @@ static quad_t get_ms() {
 static void get_pids(std::set<pid_t> *pids) {
   DIR *proc = opendir("/proc");
   if (proc == 0) {
-    std::cerr << "Error reading /proc, needed to get inode-to-pid-mapping"
-              << std::endl;
+    std::cerr << "Error reading /proc, needed to get pid set" << std::endl;
     exit(1);
   }
   dirent *entry;

--- a/src/inode2prog.cpp
+++ b/src/inode2prog.cpp
@@ -235,7 +235,8 @@ static quad_t get_ms() {
 static void get_pids(std::set<pid_t> *pids) {
   DIR *proc = opendir("/proc");
   if (proc == 0) {
-    std::cerr << "Error reading /proc, needed to get inode-to-pid-mapping" << std::endl;
+    std::cerr << "Error reading /proc, needed to get inode-to-pid-mapping"
+              << std::endl;
     exit(1);
   }
   dirent *entry;

--- a/src/inode2prog.cpp
+++ b/src/inode2prog.cpp
@@ -235,7 +235,7 @@ static quad_t get_ms() {
 static void get_pids(std::set<pid_t> *pids) {
   DIR *proc = opendir("/proc");
   if (proc == 0) {
-    std::cerr << "Error reading /proc, needed to get inode-to-pid-maping\n";
+    std::cerr << "Error reading /proc, needed to get inode-to-pid-mapping" << std::endl;
     exit(1);
   }
   dirent *entry;

--- a/src/inode2prog.h
+++ b/src/inode2prog.h
@@ -41,4 +41,6 @@ void prg_cache_clear();
 // reread the inode-to-prg_node-mapping
 void reread_mapping();
 
+void garbage_collect_inodeproc();
+
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -322,6 +322,7 @@ int main(int argc, char **argv) {
         ui_tick();
       }
       do_refresh();
+      garbage_collect_processes();
     }
 
     // if not packets, do a select() until next packet

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -424,3 +424,5 @@ void remove_timed_out_processes() {
     previousproc = curproc;
   }
 }
+
+void garbage_collect_processes() { garbage_collect_inodeproc(); }

--- a/src/process.h
+++ b/src/process.h
@@ -145,4 +145,6 @@ void procclean();
 
 void remove_timed_out_processes();
 
+void garbage_collect_processes();
+
 #endif


### PR DESCRIPTION
Hi @raboof ,

I've implemented garbage collection for inodeproc.
It releases the members for exited processes on each ui refresh.

My concern about this PR, is performance impact.
The time complexity of garbage_collect_inodeproc is O(MlogN),  (M: inode number, N: process number).
In my desktop PC (Intel(R) Core(TM) i7-10510U CPU @ 1.80GHz), it takes around 1-4ms.
If you think it's critical, I guess we can thin out the garbage collection timing.

```
$ sudo nethogs -Cb | grep 'GC proc'
PERF: GC proctime: 1[ms]
PERF: GC proctime: 1[ms]
PERF: GC proctime: 1[ms]
PERF: GC proctime: 1[ms]
PERF: GC proctime: 2[ms]
PERF: GC proctime: 4[ms]
```

I'm not sure that this is the exact reason of #96 .
But when I've tried to reproduce memory leak with valgrind for 1 week,
almost all memory leak occur within members of inodeproc.

I know they are not leaked, because inodeproc hold their pointer.
But inode space is very huge, so I guess it's better to release unnecessary members.

```
$ sudo valgrind --leak-check=full nethogs
...
==5174== 21,580,283 (3,685,392 direct, 17,894,891 indirect) bytes in 76,779 blocks are definitely lost in loss record 86 of 88
==5174==    at 0x4C2E0EF: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==5174==    by 0x40A1A1: setnode(unsigned long, int) (inode2prog.cpp:165)
==5174==    by 0x40A31C: get_info_by_linkname(char const*, char const*) (inode2prog.cpp:177)
==5174==    by 0x40A519: get_info_for_pid(char const*) (inode2prog.cpp:222)
==5174==    by 0x40A5B0: reread_mapping() (inode2prog.cpp:246)
==5174==    by 0x40A6E5: findPID(unsigned long) (inode2prog.cpp:263)
==5174==    by 0x406527: getProcess(unsigned long, char const*) (process.cpp:252)
==5174==    by 0x406D85: getProcess(Connection*, char const*, short) (process.cpp:378)
==5174==    by 0x403AFF: process_tcp(unsigned char*, pcap_pkthdr const*, unsigned char const*) (nethogs.cpp:153)
==5174==    by 0x4079FC: dp_parse_tcp (decpcap.c:128)
==5174==    by 0x407A61: dp_parse_ip (decpcap.c:164)
==5174==    by 0x407B3D: dp_parse_ethernet (decpcap.c:221)
==5174== 
==5174== 30,985,739 (5,219,040 direct, 25,766,699 indirect) bytes in 108,730 blocks are definitely lost in loss record 88 of 88
==5174==    at 0x4C2E0EF: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==5174==    by 0x40A1A1: setnode(unsigned long, int) (inode2prog.cpp:165)
==5174==    by 0x40A31C: get_info_by_linkname(char const*, char const*) (inode2prog.cpp:177)
==5174==    by 0x40A519: get_info_for_pid(char const*) (inode2prog.cpp:222)
==5174==    by 0x40A5B0: reread_mapping() (inode2prog.cpp:246)
==5174==    by 0x406AE4: getProcess(Connection*, char const*, short) (process.cpp:330)
==5174==    by 0x403AFF: process_tcp(unsigned char*, pcap_pkthdr const*, unsigned char const*) (nethogs.cpp:153)
==5174==    by 0x4079FC: dp_parse_tcp (decpcap.c:128)
==5174==    by 0x407A61: dp_parse_ip (decpcap.c:164)
==5174==    by 0x407B3D: dp_parse_ethernet (decpcap.c:221)
==5174==    by 0x407C8B: dp_pcap_callback (decpcap.c:332)
==5174==    by 0x4E3FEF5: ??? (in /usr/lib/x86_64-linux-gnu/libpcap.so.1.7.4)
==5174== 
==5174== LEAK SUMMARY:
==5174==    definitely lost: 8,909,348 bytes in 185,512 blocks
==5174==    indirectly lost: 43,670,792 bytes in 185,227 blocks
==5174==      possibly lost: 5,540 bytes in 13 blocks
==5174==    still reachable: 450,517 bytes in 517 blocks
==5174==         suppressed: 0 bytes in 0 blocks
```