### PR TITLE
Fix compilation error with [-Werror=format-security]

### DIFF
--- a/src/cui.cpp
+++ b/src/cui.cpp
@@ -374,9 +374,9 @@ void show_ncurses(Line *lines[], int nproc) {
   int totalrow = std::min(rows - 1, 3 + 1 + i);
   mvprintw(totalrow, 0, "  TOTAL        %-*.*s %-*.*s    %11.3f %11.3f ",
            proglen, proglen, "", devlen, devlen, "", sent_global, recv_global);
-  mvprintw(3 + 1 + i, cols - COLUMN_WIDTH_UNIT, desc_view_mode[viewMode]);
+  mvprintw(3 + 1 + i, cols - COLUMN_WIDTH_UNIT, "%s", desc_view_mode[viewMode]);
   attroff(A_REVERSE);
-  mvprintw(totalrow + 1, 0, "");
+  mvprintw(totalrow + 1, 0, "%s", "");
   refresh();
 }
 


### PR DESCRIPTION
When compiling with [-Werror=format-security] in Debian packaging occurs this error:
```
cui.cpp: In function ‘void show_ncurses(Line**, int)’:                                          
cui.cpp:377:73: error: format not a string literal and no format arguments [-Werror=format-security]
  377 |   mvprintw(3 + 1 + i, cols - COLUMN_WIDTH_UNIT, desc_view_mode[viewMode]);              
      |                                                                         ^               
cui.cpp:379:29: warning: zero-length gnu_printf format string [-Wformat-zero-length]            
  379 |   mvprintw(totalrow + 1, 0, "");                                                        
      |                             ^~      
```

This patch solve the problem.

[]'s
kretcheu