### PR TITLE
feat: Add basename support #155

### DIFF
--- a/doc/nethogs.8
+++ b/doc/nethogs.8
@@ -19,6 +19,7 @@ nethogs \- Net top tool grouping bandwidth per process
 .RB [ "\-l" ]
 .RB [ "\-f filter" ]
 .RB [ "\-C" ]
+.RB [ "\-b" ]
 .RB [ "\-g period" ]
 .RI [device(s)]
 .SH DESCRIPTION
@@ -62,6 +63,9 @@ monitor all devices, even loopback/stopped ones.
 \fB-C\fP
 capture TCP and UDP.
 .TP
+\fB-b\fP
+Display the program basename.
+.TP
 \fB-g\fP
 garbage collection period in number of refresh. default is 50.
 .TP
@@ -85,6 +89,9 @@ sort by RECEIVED traffic
 .TP
 l
 display command line
+.TP
+b
+display the program basename
 .TP
 m
 switch between total (KB, B, MB) and throughput (KB/s, MB/s, GB/s) mode

--- a/doc/nethogs.8
+++ b/doc/nethogs.8
@@ -8,7 +8,7 @@ nethogs \- Net top tool grouping bandwidth per process
 .B nethogs
 .RB [ "\-V" ]
 .RB [ "\-h" ]
-.RB [ "\-b" ]
+.RB [ "\-x" ]
 .RB [ "\-d seconds" ]
 .RB [ "\-v mode" ]
 .RB [ "\-c count" ]
@@ -32,7 +32,7 @@ prints version.
 \fB-h\fP
 prints available commands usage.
 .TP
-\fB-b\fP
+\fB-x\fP
 bughunt mode - implies tracemode.
 .TP
 \fB-d\fP

--- a/src/cui.cpp
+++ b/src/cui.cpp
@@ -26,6 +26,7 @@
 #include <cstdlib>
 #include <pwd.h>
 #include <string>
+#include <strings.h>
 #include <sys/types.h>
 
 #include "nethogs.h"
@@ -45,6 +46,7 @@ extern bool sortRecv;
 
 extern int viewMode;
 extern bool showcommandline;
+extern bool showBasename;
 
 extern unsigned refreshlimit;
 extern unsigned refreshcount;
@@ -66,6 +68,8 @@ const char *COLUMN_FORMAT_RECEIVED = "%11.3f";
 // All descriptions are padded to 6 characters in length with spaces
 const char *const desc_view_mode[VIEWMODE_COUNT] = {
     "KB/sec", "KB    ", "B     ", "MB    ", "MB/sec", "GB/sec"};
+
+constexpr char FILE_SEPARATOR = '/';
 
 class Line {
 public:
@@ -152,6 +156,12 @@ static void mvaddstr_truncate_trailing(int row, int col, const char *str,
 static void mvaddstr_truncate_cmdline(int row, int col, const char *progname,
                                       const char *cmdline,
                                       std::size_t max_len) {
+  if (showBasename) {
+    if (index(progname, FILE_SEPARATOR) != NULL) {
+      progname = rindex(progname, FILE_SEPARATOR) + 1;
+    } 
+  }                                      
+
   std::size_t proglen = strlen(progname);
   std::size_t max_cmdlen;
 
@@ -304,6 +314,10 @@ void ui_tick() {
   case 'm':
     /* switch mode: total vs kb/s */
     viewMode = (viewMode + 1) % VIEWMODE_COUNT;
+    break;
+  case 'b':
+    /* show only the process basename */
+    showBasename = !showBasename;
     break;
   }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,7 +27,7 @@ static void help(bool iserror) {
   // output << "usage: nethogs [-V] [-b] [-d seconds] [-t] [-p] [-f (eth|ppp))]
   // [device [device [device ...]]]\n";
   output << "usage: nethogs [-V] [-h] [-x] [-d seconds] [-v mode] [-c count] "
-            "[-t] [-p] [-s] [-a] [-l] [-f filter] [-C]"
+            "[-t] [-p] [-s] [-a] [-l] [-f filter] [-C] [-b]"
             "[device [device [device ...]]]\n";
   output << "		-V : prints version.\n";
   output << "		-h : prints this help.\n";
@@ -48,6 +48,7 @@ static void help(bool iserror) {
   output << "		-C : capture TCP and UDP.\n";
   output << "		-g : garbage collection period in number of refresh. "
             "default is 50.\n";
+  output << "		-b : Short program name. Displays only the program name.\n";
   output << "		-f : EXPERIMENTAL: specify string pcap filter (like "
             "tcpdump)."
             " This may be removed or changed in a future version.\n";
@@ -59,6 +60,7 @@ static void help(bool iserror) {
   output << " s: sort by SENT traffic\n";
   output << " r: sort by RECEIVED traffic\n";
   output << " l: display command line\n";
+  output << " b: display the program basename instead of the fullpath\n";
   output << " m: switch between total (KB, B, MB) and throughput (KB/s, MB/s, "
             "GB/s) mode\n";
 }
@@ -145,7 +147,7 @@ int main(int argc, char **argv) {
   int garbage_collection_period = 50;
 
   int opt;
-  while ((opt = getopt(argc, argv, "Vhxtpsd:v:c:laf:Cg:")) != -1) {
+  while ((opt = getopt(argc, argv, "Vhxtpsd:v:c:laf:Cbg:")) != -1) {
     switch (opt) {
     case 'V':
       versiondisplay();
@@ -186,6 +188,9 @@ int main(int argc, char **argv) {
       break;
     case 'C':
       catchall = true;
+      break;
+    case 'b':
+      showBasename = true;
       break;
     case 'g':
       garbage_collection_period = (time_t)atoi(optarg);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,12 +26,12 @@ static void help(bool iserror) {
 
   // output << "usage: nethogs [-V] [-b] [-d seconds] [-t] [-p] [-f (eth|ppp))]
   // [device [device [device ...]]]\n";
-  output << "usage: nethogs [-V] [-h] [-b] [-d seconds] [-v mode] [-c count] "
+  output << "usage: nethogs [-V] [-h] [-x] [-d seconds] [-v mode] [-c count] "
             "[-t] [-p] [-s] [-a] [-l] [-f filter] [-C]"
             "[device [device [device ...]]]\n";
   output << "		-V : prints version.\n";
   output << "		-h : prints this help.\n";
-  output << "		-b : bughunt mode - implies tracemode.\n";
+  output << "		-x : bughunt mode - implies tracemode.\n";
   output << "		-d : delay for update refresh rate in seconds. default "
             "is 1.\n";
   output << "		-v : view mode (0 = KB/s, 1 = total KB, 2 = total B, 3 "
@@ -145,7 +145,7 @@ int main(int argc, char **argv) {
   int garbage_collection_period = 50;
 
   int opt;
-  while ((opt = getopt(argc, argv, "Vhbtpsd:v:c:laf:Cg:")) != -1) {
+  while ((opt = getopt(argc, argv, "Vhxtpsd:v:c:laf:Cg:")) != -1) {
     switch (opt) {
     case 'V':
       versiondisplay();
@@ -153,7 +153,7 @@ int main(int argc, char **argv) {
     case 'h':
       help(false);
       exit(0);
-    case 'b':
+    case 'x':
       bughuntmode = true;
       tracemode = true;
       break;

--- a/src/nethogs.cpp
+++ b/src/nethogs.cpp
@@ -60,6 +60,7 @@ bool bughuntmode = false;
 // sort on sent or received?
 bool sortRecv = true;
 bool showcommandline = false;
+bool showBasename = false;
 // viewMode: kb/s or total
 int viewMode = VIEWMODE_KBPS;
 const char version[] = " version " VERSION;


### PR DESCRIPTION
Hi, I did this simple implementation, hope it can be useful.

User, can have the choice to see only the program name, instead of the full path. 
It seems useful when you have a program that resides on a big directory hierarchy. 

I used the *b* flag, to enable/disable the short process name. I saw, that its the same flag to enable bug hunt mode. I can change, if you request. 

This is my first pull request on a project ... So, if I am doing something wrong, please, tell me! 

Thanks in advance ... 
Best Regards, Matheus Rambo. 

Closes #155 
