### PR TITLE
Add process filter 

### DIFF
--- a/doc/nethogs.8
+++ b/doc/nethogs.8
@@ -21,6 +21,7 @@ nethogs \- Net top tool grouping bandwidth per process
 .RB [ "\-C" ]
 .RB [ "\-b" ]
 .RB [ "\-g period" ]
+.RB [ "\-P pid" ]
 .RI [device(s)]
 .SH DESCRIPTION
 NetHogs is a small 'net top' tool. Instead of breaking the traffic down per protocol or per subnet, like most such tools do, it groups bandwidth by process - and does not rely on a special kernel module to be loaded. So if there's suddenly a lot of network traffic, you can fire up NetHogs and immediately see which PID is causing this, and if it's some kind of spinning process, kill it.
@@ -69,6 +70,9 @@ Display the program basename.
 \fB-g\fP
 garbage collection period in number of refresh. default is 50.
 .TP
+\fB-P\fP
+Show only processes with the specified pid(s).
+.TP
 \fB-f\fP
 EXPERIMENTAL: specify string pcap filter (like tcpdump). This may be removed or changed in a future version.
 .TP
@@ -113,7 +117,9 @@ command, as follows:
 sudo setcap "cap_net_admin,cap_net_raw+pe" /usr/local/sbin/nethogs
 .EE
 .in
-
+.SH "Notes"
+1. When using the -P <pid> option, in a case where a process exited (normally or abruptly), Nethogs does not track that it exited. So, the operating system might create 
+a new process (for another program) with the same pid. In this case, this new process will be shown by Nethogs.
 .SH "SEE ALSO"
 .I netstat(8) tcpdump(1) pcap(3)
 .SH AUTHOR


### PR DESCRIPTION
Add new option(**-P \<pid>**) to show only traffic about process that the user wants to.  
Other processes are caught as *unknown tcp/udp*

- [x]  Update the manual page. I also added a **note** section that mentions about the behavior of **nethogs** when the watched process exit.
- [x] Update the help message.  
- [x] Add code to let the user filter processes by *pid*. 
- [x] Tested on Freebsd .