### PR TITLE
Use "--tags" parameter to get the correct git-tag

### DIFF
--- a/determineVersion.sh
+++ b/determineVersion.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-(git describe 2>/dev/null || pwd | sed -e "s/.*\\///" | sed -e "s/[^-]*//") | tail -c +2
+(git describe --tags 2>/dev/null || pwd | sed -e "s/.*\\///" | sed -e "s/[^-]*//") | tail -c +2


### PR DESCRIPTION
For me the correct tag only appears when using the "--tags" parameter.
My use case was to checkout the last tag and compiling on ubuntu 20.04.

Does this also work in all of your use cases?