### PR TITLE
Add `-std=c++14` for application build

### DIFF
--- a/src/MakeApp.mk
+++ b/src/MakeApp.mk
@@ -5,7 +5,7 @@ all: nethogs decpcap_test
 # nethogs_testsum
 
 CFLAGS?=-Wall -Wextra
-CXXFLAGS?=-Wall -Wextra -Wno-missing-field-initializers
+CXXFLAGS?=-Wall -Wextra -Wno-missing-field-initializers -std=c++14
 
 OBJS=packet.o connection.o process.o decpcap.o cui.o inode2prog.o conninode.o devices.o
 


### PR DESCRIPTION
To address:

  https://github.com/raboof/nethogs/issues/225

add the `-std=c++14` flag when building the application.

This then compiles properly with the Apple version of the Clang
compiler:

  Apple clang version 11.0.0 (clang-1100.0.33.17)

Additionally, this removed some warning noise regarding C++11
extensions used without the appropriate `-std=c++11` (or greater)
flag:

  ./process.h:38:26: warning: alias declarations are a C++11 extension [-Wc++11-extensions]
  connection.cpp:107:3: warning: 'auto' type specifier is a C++11 extension [-Wc++11-extensions]
  connection.cpp:108:8: warning: 'auto' type specifier is a C++11 extension [-Wc++11-extensions]
  connection.cpp:162:3: warning: 'auto' type specifier is a C++11 extension [-Wc++11-extensions]
  connection.cpp:187:3: warning: 'auto' type specifier is a C++11 extension [-Wc++11-extensions]