### PR TITLE
Additional useful capabilities

### DIFF
--- a/doc/nethogs.8
+++ b/doc/nethogs.8
@@ -108,13 +108,18 @@ needs the
 .I cap_net_admin
 and
 .I cap_net_raw
-capabilities. These can be set on the executable by using the
+capabilities. Additionally, to display process names,
+.I cap_dac_read_search
+and
+.I cap_sys_ptrace
+capabilities are required.
+These can be set on the executable by using the
 .BR setcap (8)
 command, as follows:
 .PP
 .in +4n
 .EX
-sudo setcap "cap_net_admin,cap_net_raw+pe" /usr/local/sbin/nethogs
+sudo setcap "cap_net_admin,cap_net_raw,cap_dac_read_search,cap_sys_ptrace+pe" /usr/local/sbin/nethogs
 .EE
 .in
 .SH "Notes"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -215,15 +215,12 @@ int main(int argc, char **argv) {
     forceExit(false, "No devices to monitor. Use '-a' to allow monitoring "
                      "loopback interfaces or devices that are not up/running");
 
-  if ((!tracemode) && (!DEBUG)) {
-    init_ui();
-  }
-
 #ifndef __linux__
   if (geteuid() != 0)
     forceExit(false, "You need to be root to run NetHogs!");
 #endif
-  // on Linux, we can run as non-root given the cap_net_admin and cap_net_raw capabilities
+  // on Linux, we can run as non-root given the cap_net_admin, cap_net_raw,
+  // cap_dac_read_search and cap_sys_ptrace capabilities
 
   // use the Self-Pipe trick to interrupt the select() in the main loop
   self_pipe = create_self_pipe();
@@ -291,7 +288,8 @@ int main(int argc, char **argv) {
   if (nb_devices == nb_failed_devices) {
     if (geteuid() != 0)
       fprintf(stderr, "To run nethogs without being root, you need to enable "
-                      "capabilities on the program (cap_net_admin, cap_new_raw). "
+                      "capabilities on the program (cap_net_admin, cap_net_raw, "
+                      "cap_dac_read_search, cap_sys_ptrace). "
                       "See the documentation for details.\n");
     forceExit(false, "Error opening pcap handlers for all devices.\n");
   }
@@ -299,6 +297,10 @@ int main(int argc, char **argv) {
   signal(SIGINT, &quit_cb);
 
   struct dpargs *userdata = (dpargs *)malloc(sizeof(struct dpargs));
+
+  if ((!tracemode) && (!DEBUG)) {
+    init_ui();
+  }
 
   // Main loop:
   int refresh_count = 0;


### PR DESCRIPTION
Following #233, here's an update for main.cpp (error message and comment), and the man page.

A first important point is that the error message was not shown on the console. The unexpected behavior was introduced with #231 as far as I can tell. I have no experience of ncurses, but my feeling is that initializing it (calling `init_ui`) before outputting to stderr/stdout messes up the console output. My tentative solution is to defer initialization to just before main loop (lines 301-304 in this PR), which in my tests works well for error and normal cases. (Before #231, behavior was also messy, in the sense that newlines were not displayed properly in the console.)

The second point is that the long `setcap` command line in the man page looks quite ugly. I quickly tried to look at groff macros, but that looks like a lot of complicated stuff, so trying to find an elegant way to display that is not something I can help much with I'm afraid..