### PR TITLE
Add -std=c++14 for application build

### DIFF
--- a/src/MakeLib.mk
+++ b/src/MakeLib.mk
@@ -26,12 +26,12 @@ ifeq ($(DEBUG),1)
   $(info Building debug version)
   ODIR:=$(ODIR_BASE)/lib/debug
   CFLAGS?=-Wall -Wextra -O0 -g -fPIC $(VISIBILITY)
-  CXXFLAGS?=-Wall -Wextra -Wno-missing-field-initializers --std=c++0x -O0 -g -fPIC $(VISIBILITY) $(CXXINCLUDES)
+  CXXFLAGS?=-Wall -Wextra -Wno-missing-field-initializers --std=c++14 -O0 -g -fPIC $(VISIBILITY) $(CXXINCLUDES)
 else
   # Release mode options
   ODIR:=$(ODIR_BASE)/lib/release
   CFLAGS?=-Wall -Wextra -O3 -fPIC $(VISIBILITY)
-  CXXFLAGS?=-Wall -Wextra -Wno-missing-field-initializers --std=c++0x -O3 -fPIC $(VISIBILITY) $(CXXINCLUDES)
+  CXXFLAGS?=-Wall -Wextra -Wno-missing-field-initializers --std=c++14 -O3 -fPIC $(VISIBILITY) $(CXXINCLUDES)
 endif
 
 OBJ_NAMES= libnethogs.o packet.o connection.o process.o decpcap.o inode2prog.o conninode.o devices.o


### PR DESCRIPTION
Add the -std=c++14 flag when building the application.
#235 