### PR TITLE
Fix wrong extern declaration of pidsToWatch

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,7 +15,7 @@
 static std::pair<int, int> self_pipe = std::make_pair(-1, -1);
 static time_t last_refresh_time = 0;
 
-std::set<pid_t> pidsToWatch;
+extern std::set<pid_t> pidsToWatch;
 
 // selectable file descriptors for the main loop
 static fd_set pc_loop_fd_set;

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -68,7 +68,7 @@ Process *unknownudp;
 Process *unknownip;
 ProcList *processes;
 
-extern std::set<pid_t> pidsToWatch;
+std::set<pid_t> pidsToWatch;
 
 #define KB (1UL << 10)
 #define MB (1UL << 20)


### PR DESCRIPTION
# The bug

Since *pidsToWatch* was declared in the `main.cpp` file, compilations which uses only the headers have an undefined symbol.

I have just moved the definition to the `process.cpp` class, which will be included in all binaries.

# Checks

I am not sure how to check to reproduce the error from https://github.com/raboof/nethogs/issues/230

I have run: `make` & `make libnethogs` which compiled successfully

![image](https://user-images.githubusercontent.com/33197461/226911626-32b9806e-6c8b-43c0-bf86-2a1ac0daaeab.png)

If you have another way to test the, I would be glad to learn 

