### PR TITLE
fix python bindings

### DIFF
--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -9,7 +9,7 @@
 namespace py = pybind11;
 
 //--- for some reason this is a global defined in main.cpp
-std::set<pid_t> pidsToWatch;
+extern std::set<pid_t> pidsToWatch;
 
 //--- hacky way to get callbacks working and handle signals
 std::function<void(int, NethogsMonitorRecord const *)> empty_callback;


### PR DESCRIPTION
Hey,

This small PR fixes the Python bindings and makes `pip install` work again.

Best,

Andreas