### PR TITLE
Report only changes of send and received data

### DIFF
--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -76,6 +76,8 @@ PYBIND11_MODULE(nethogs, m) {
         .def_readwrite("device_name", &NethogsMonitorRecord::device_name)
         .def_readwrite("sent_bytes", &NethogsMonitorRecord::sent_bytes)
         .def_readwrite("recv_bytes", &NethogsMonitorRecord::recv_bytes)
+        .def_readwrite("sent_bytes_last", &NethogsMonitorRecord::sent_bytes_last)
+        .def_readwrite("recv_bytes_last", &NethogsMonitorRecord::sent_bytes_last)
         .def_readwrite("sent_kbs", &NethogsMonitorRecord::sent_kbs)
         .def_readwrite("recv_kbs", &NethogsMonitorRecord::recv_kbs);
 

--- a/src/libnethogs.cpp
+++ b/src/libnethogs.cpp
@@ -207,10 +207,14 @@ static void nethogsmonitor_handle_update(NethogsMonitorCallback cb) {
       const u_int32_t uid = curproc->getVal()->getUid();
       u_int64_t sent_bytes;
       u_int64_t recv_bytes;
+      u_int64_t sent_bytes_last;
+      u_int64_t recv_bytes_last;
+
       float sent_kbs;
       float recv_kbs;
       curproc->getVal()->getkbps(&recv_kbs, &sent_kbs);
       curproc->getVal()->gettotal(&recv_bytes, &sent_bytes);
+      curproc->getVal()->getlast(&recv_bytes_last, &sent_bytes_last);
 
       // notify update
       bool const new_data =
@@ -239,8 +243,11 @@ static void nethogsmonitor_handle_update(NethogsMonitorCallback cb) {
       NHM_UPDATE_ONE_FIELD(data.uid, uid)
       NHM_UPDATE_ONE_FIELD(data.sent_bytes, sent_bytes)
       NHM_UPDATE_ONE_FIELD(data.recv_bytes, recv_bytes)
+      NHM_UPDATE_ONE_FIELD(data.sent_bytes_last, sent_bytes_last)
+      NHM_UPDATE_ONE_FIELD(data.recv_bytes_last, recv_bytes_last)
       NHM_UPDATE_ONE_FIELD(data.sent_kbs, sent_kbs)
       NHM_UPDATE_ONE_FIELD(data.recv_kbs, recv_kbs)
+
 
 #undef NHM_UPDATE_ONE_FIELD
 

--- a/src/libnethogs.h
+++ b/src/libnethogs.h
@@ -26,6 +26,8 @@ typedef struct NethogsMonitorRecord {
   const char *device_name;
   uint64_t sent_bytes;
   uint64_t recv_bytes;
+  uint64_t sent_bytes_last;
+  uint64_t recv_bytes_last;
   float sent_kbs;
   float recv_kbs;
 } NethogsMonitorRecord;

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -200,8 +200,8 @@ void Process::getlast(u_int64_t *recvd, u_int64_t *sent) {
   *sent = sum_sent - this->sent_last_reported;
   *recvd = sum_recv - this->rcvd_last_reported;
 
-  this->sent_last_reported = *sent;
-  this->rcvd_last_reported = *recvd;
+  this->sent_last_reported = sum_sent;
+  this->rcvd_last_reported = sum_recv;
 }
 
 

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -192,6 +192,20 @@ void Process::gettotalb(float *recvd, float *sent) {
   *recvd = sum_recv;
 }
 
+/** get only bytes since last request */
+void Process::getlast(u_int64_t *recvd, u_int64_t *sent) {
+  u_int64_t sum_sent = 0, sum_recv = 0;
+  gettotal(&sum_recv, &sum_sent);
+  
+  *sent = sum_sent - this->sent_last_reported;
+  *recvd = sum_recv - this->rcvd_last_reported;
+
+  this->sent_last_reported = *sent;
+  this->rcvd_last_reported = *recvd;
+}
+
+
+
 Process *findProcess(struct prg_node *node) {
   ProcList *current = processes;
   while (current != NULL) {

--- a/src/process.h
+++ b/src/process.h
@@ -77,6 +77,8 @@ public:
     uid = 0;
     sent_by_closed_bytes = 0;
     rcvd_by_closed_bytes = 0;
+    sent_last_reported = 0;
+    rcvd_last_reported = 0;
   }
   void check() { assert(pid >= 0); }
 
@@ -95,6 +97,7 @@ public:
   void gettotalmb(float *recvd, float *sent);
   void gettotalkb(float *recvd, float *sent);
   void gettotalb(float *recvd, float *sent);
+  void getlast(u_int64_t *recvd, u_int64_t *sent);
 
   char *name;
   char *cmdline;
@@ -102,6 +105,9 @@ public:
   int pid;
   u_int64_t sent_by_closed_bytes;
   u_int64_t rcvd_by_closed_bytes;
+
+  u_int64_t sent_last_reported;
+  u_int64_t rcvd_last_reported;
 
   ConnList connections;
   uid_t getUid() { return uid; }


### PR DESCRIPTION
Hey,

this patch adds a property that allows us to process only the sent and received data since the last request. This PR might be useful in the library mode. As each process has a limited lifetime, but might reappear with the same PID and/or name, it might happen, that a process drops from 1000 GB of sent or received data to 0.0001 GB, which is unnecessarily hard to deal with. However, if changes are reported, an app can deal with things more easily.

A use case is https://github.com/AndreasGocht/netgraph , which pushes the data from nethogs to an influx db, which can then be visualised using Grafana.

Best,

Andreas