### PR TITLE
Clarify units

### DIFF
--- a/doc/nethogs.8
+++ b/doc/nethogs.8
@@ -41,7 +41,9 @@ bughunt mode - implies tracemode.
 delay for update refresh rate in seconds. default is 1.
 .TP
 \fB-v\fP
-view mode (0 = KB/s, 1 = total KB, 2 = total B, 3 = total MB, 4 = MB/s, 5 = GB/s). default is 0.
+view mode (0 = kB/s, 1 = total kB, 2 = total bytes, 3 = total MB, 4 = MB/s, 5 = GB/s). default is 0.
+
+kB: 2e10 bytes, MB: 2e20 bytes, GB: 2e30 bytes
 .TP
 \fB-c\fP
 number of updates. default is 0 (unlimited).

--- a/src/cui.cpp
+++ b/src/cui.cpp
@@ -68,7 +68,7 @@ const char *COLUMN_FORMAT_RECEIVED = "%11.3f";
 
 // All descriptions are padded to 6 characters in length with spaces
 const char *const desc_view_mode[VIEWMODE_COUNT] = {
-    "KB/s  ", "KB    ", "B     ", "MB    ", "MB/s  ", "GB/s  "};
+    "kB/s  ", "kB    ", "bytes ", "MB    ", "MB/s  ", "GB/s  "};
 
 constexpr char FILE_SEPARATOR = '/';
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,8 +37,8 @@ static void help(bool iserror) {
   output << "		-x : bughunt mode - implies tracemode.\n";
   output << "		-d : delay for update refresh rate in seconds. default "
             "is 1.\n";
-  output << "		-v : view mode (0 = KB/s, 1 = total KB, 2 = total B, 3 "
-            "= total MB, 4 = MB/s, 5 = GB/s). default is 0.\n";
+  output << "		-v : view mode (0 = kB/s, 1 = total kB, 2 = "
+            "total bytes, 3 = total MB, 4 = MB/s, 5 = GB/s). default is 0.\n";
   output << "		-c : number of updates. default is 0 (unlimited).\n";
   output << "		-t : tracemode.\n";
   // output << "		-f : format of packets on interface, default is
@@ -66,8 +66,8 @@ static void help(bool iserror) {
   output << " r: sort by RECEIVED traffic\n";
   output << " l: display command line\n";
   output << " b: display the program basename instead of the fullpath\n";
-  output << " m: switch between total (KB, B, MB) and throughput (KB/s, MB/s, "
-            "GB/s) mode\n";
+  output << " m: switch between total (kB, bytes, MB) and throughput (kB/s, "
+            " MB/s, GB/s) mode\n";
 }
 
 void quit_cb(int /* i */) {


### PR DESCRIPTION
On the internet the usage of b and B for bits or bytes is inconsistent.

Lowercase b seems to be used for either, and upperace B is more often used to mean bytes but usege for bits also exists.

I am not aware of any standard that would mandate one or other use.

Consequently, spelling out the whole word in the output or adding explanation in documentation is the only way to make sure the output is interpreted correctly.

To save space on small screens only alter documentation and the bytes label without prefixes/suffixes.

While at it change uppercase K to lowercase k to correctly spell the kilo- prefix.

Fixes: #261