### PR TITLE
fix an copy-and-paste error in the bindings

### DIFF
--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -77,7 +77,7 @@ PYBIND11_MODULE(nethogs, m) {
         .def_readwrite("sent_bytes", &NethogsMonitorRecord::sent_bytes)
         .def_readwrite("recv_bytes", &NethogsMonitorRecord::recv_bytes)
         .def_readwrite("sent_bytes_last", &NethogsMonitorRecord::sent_bytes_last)
-        .def_readwrite("recv_bytes_last", &NethogsMonitorRecord::sent_bytes_last)
+        .def_readwrite("recv_bytes_last", &NethogsMonitorRecord::recv_bytes_last)
         .def_readwrite("sent_kbs", &NethogsMonitorRecord::sent_kbs)
         .def_readwrite("recv_kbs", &NethogsMonitorRecord::recv_kbs);
 


### PR DESCRIPTION
I just found a copy-and-paste error in the Python bindings.

Best,

Andreas