### PR TITLE
Add -j option for newline-delimited JSON output in tracemode

### DIFF
--- a/src/cui.cpp
+++ b/src/cui.cpp
@@ -464,7 +464,7 @@ void do_refresh() {
   /* sort the accumulated lines */
   qsort(lines, nproc, sizeof(Line *), GreatestFirst);
   if (jsontrace)
-    show_json_trace(lines, nproc)
+    show_json_trace(lines, nproc);
   if (tracemode || DEBUG)
     show_trace(lines, nproc);
   else

--- a/src/cui.cpp
+++ b/src/cui.cpp
@@ -325,7 +325,18 @@ void ui_tick() {
     break;
   }
 }
-
+void show_json_trace(Line *lines[], int nproc) {
+  /* print them */
+  std::cout << '[';
+  for (int i = 0; i < nproc; i++)
+  {
+    lines[i]->log_json();
+    delete lines[i];
+    if (i != nproc - 1)
+      std::cout << ',';
+  }
+  std::cout << ']' << std::endl;
+}
 void show_trace(Line *lines[], int nproc) {
   std::cout << "\nRefreshing:\n";
 
@@ -452,7 +463,8 @@ void do_refresh() {
 
   /* sort the accumulated lines */
   qsort(lines, nproc, sizeof(Line *), GreatestFirst);
-
+  if (jsontrace)
+    show_json_trace(lines, nproc)
   if (tracemode || DEBUG)
     show_trace(lines, nproc);
   else

--- a/src/cui.cpp
+++ b/src/cui.cpp
@@ -90,6 +90,7 @@ public:
 
   void show(int row, unsigned int proglen, unsigned int devlen);
   void log();
+  void log_json();
 
   double sent_value;
   double recv_value;
@@ -222,6 +223,11 @@ void Line::show(int row, unsigned int proglen, unsigned int devlen) {
 
   mvprintw(row, column_offset_received, COLUMN_FORMAT_RECEIVED, recv_value);
   mvaddstr(row, column_offset_unit, desc_view_mode[viewMode]);
+}
+void Line::log_json()
+{
+  printf("{\"name\":\"%s\",\"PID\":%d,\"UID\":%d,\"TX\":%f,\"RX\":%f }",
+         m_name, m_pid, m_uid, sent_value, recv_value);
 }
 
 void Line::log() {

--- a/src/cui.cpp
+++ b/src/cui.cpp
@@ -72,10 +72,12 @@ const char *const desc_view_mode[VIEWMODE_COUNT] = {
 
 constexpr char FILE_SEPARATOR = '/';
 
-class Line {
+class Line
+{
 public:
   Line(const char *name, const char *cmdline, double n_recv_value,
-       double n_sent_value, pid_t pid, uid_t uid, const char *n_devicename) {
+       double n_sent_value, pid_t pid, uid_t uid, const char *n_devicename)
+  {
     assert(pid >= 0);
     assert(pid <= PID_MAX);
     m_name = name;
@@ -105,7 +107,8 @@ private:
 
 #include <sstream>
 
-std::string itoa(int i) {
+std::string itoa(int i)
+{
   std::stringstream out;
   out << i;
   return out.str();
@@ -114,7 +117,8 @@ std::string itoa(int i) {
 /**
  * @returns the username that corresponds to this uid
  */
-std::string uid2username(uid_t uid) {
+std::string uid2username(uid_t uid)
+{
   struct passwd *pwd = NULL;
   errno = 0;
 
@@ -139,10 +143,14 @@ std::string uid2username(uid_t uid) {
  */
 static void mvaddstr_truncate_trailing(int row, int col, const char *str,
                                        std::size_t str_len,
-                                       std::size_t max_len) {
-  if (str_len < max_len) {
+                                       std::size_t max_len)
+{
+  if (str_len < max_len)
+  {
     mvaddstr(row, col, str);
-  } else {
+  }
+  else
+  {
     mvaddnstr(row, col, str, max_len - 2);
     addstr("..");
   }
@@ -157,9 +165,12 @@ static void mvaddstr_truncate_trailing(int row, int col, const char *str,
  */
 static void mvaddstr_truncate_cmdline(int row, int col, const char *progname,
                                       const char *cmdline,
-                                      std::size_t max_len) {
-  if (showBasename) {
-    if (index(progname, FILE_SEPARATOR) != NULL) {
+                                      std::size_t max_len)
+{
+  if (showBasename)
+  {
+    if (index(progname, FILE_SEPARATOR) != NULL)
+    {
       progname = rindex(progname, FILE_SEPARATOR) + 1;
     }
   }
@@ -167,31 +178,40 @@ static void mvaddstr_truncate_cmdline(int row, int col, const char *progname,
   std::size_t proglen = strlen(progname);
   std::size_t max_cmdlen;
 
-  if (proglen > max_len) {
+  if (proglen > max_len)
+  {
     mvaddnstr(row, col, progname, max_len - 2);
     addstr("..");
     max_cmdlen = 0;
-  } else {
+  }
+  else
+  {
     mvaddstr(row, col, progname);
     max_cmdlen = max_len - proglen - 1;
   }
 
-  if (showcommandline && cmdline) {
+  if (showcommandline && cmdline)
+  {
 
     std::size_t cmdlinelen = strlen(cmdline);
 
-    if ((cmdlinelen + 1) > max_cmdlen) {
-      if (max_cmdlen >= 3) {
+    if ((cmdlinelen + 1) > max_cmdlen)
+    {
+      if (max_cmdlen >= 3)
+      {
         mvaddnstr(row, col + proglen + 1, cmdline, max_cmdlen - 3);
         addstr("..");
       }
-    } else {
+    }
+    else
+    {
       mvaddstr(row, col + proglen + 1, cmdline);
     }
   }
 }
 
-void Line::show(int row, unsigned int proglen, unsigned int devlen) {
+void Line::show(int row, unsigned int proglen, unsigned int devlen)
+{
   assert(m_pid >= 0);
   assert(m_pid <= PID_MAX);
 
@@ -224,25 +244,29 @@ void Line::show(int row, unsigned int proglen, unsigned int devlen) {
   mvprintw(row, column_offset_received, COLUMN_FORMAT_RECEIVED, recv_value);
   mvaddstr(row, column_offset_unit, desc_view_mode[viewMode]);
 }
-void Line::log_json()
-{
-  printf("{\"name\":\"%s\",\"PID\":%d,\"UID\":%d,\"TX\":%f,\"RX\":%f }",
-         m_name, m_pid, m_uid, sent_value, recv_value);
-}
 
-void Line::log() {
+void Line::log()
+{
   std::cout << m_name;
   if (showcommandline && m_cmdline)
     std::cout << ' ' << m_cmdline;
   std::cout << '/' << m_pid << '/' << m_uid << "\t" << sent_value << "\t"
             << recv_value << std::endl;
 }
+void Line::log_json()
+{
+  printf("{\"name\":\"%s\",\"PID\":%d,\"UID\":%d,\"RX\":%f,\"TX\":%f }",
+         m_name, m_pid, m_uid, recv_value, sent_value);
+}
 
-int get_devlen(Line *lines[], int nproc, int rows) {
+int get_devlen(Line *lines[], int nproc, int rows)
+{
   int devlen = MIN_COLUMN_WIDTH_DEV;
   int curlen;
-  for (int i = 0; i < nproc; i++) {
-    if (i + 3 < rows) {
+  for (int i = 0; i < nproc; i++)
+  {
+    if (i + 3 < rows)
+    {
       curlen = strlen(lines[i]->devicename);
       if (curlen > devlen)
         devlen = curlen;
@@ -255,35 +279,45 @@ int get_devlen(Line *lines[], int nproc, int rows) {
   return devlen;
 }
 
-int GreatestFirst(const void *ma, const void *mb) {
+int GreatestFirst(const void *ma, const void *mb)
+{
   Line **pa = (Line **)ma;
   Line **pb = (Line **)mb;
   Line *a = *pa;
   Line *b = *pb;
   double aValue;
-  if (sortRecv) {
+  if (sortRecv)
+  {
     aValue = a->recv_value;
-  } else {
+  }
+  else
+  {
     aValue = a->sent_value;
   }
 
   double bValue;
-  if (sortRecv) {
+  if (sortRecv)
+  {
     bValue = b->recv_value;
-  } else {
+  }
+  else
+  {
     bValue = b->sent_value;
   }
 
-  if (aValue > bValue) {
+  if (aValue > bValue)
+  {
     return -1;
   }
-  if (aValue == bValue) {
+  if (aValue == bValue)
+  {
     return 0;
   }
   return 1;
 }
 
-void init_ui() {
+void init_ui()
+{
   WINDOW *screen = initscr();
   cursOrig = curs_set(0);
   raw();
@@ -295,7 +329,8 @@ void init_ui() {
   // caption->append(", running at ");
 }
 
-void exit_ui() {
+void exit_ui()
+{
   clear();
   endwin();
   delete caption;
@@ -303,8 +338,10 @@ void exit_ui() {
     curs_set(cursOrig);
 }
 
-void ui_tick() {
-  switch (getch()) {
+void ui_tick()
+{
+  switch (getch())
+  {
   case 'q':
     /* quit */
     quit_cb(0);
@@ -331,7 +368,8 @@ void ui_tick() {
     break;
   }
 }
-void show_json_trace(Line *lines[], int nproc) {
+void show_json_trace(Line *lines[], int nproc)
+{
   /* print them */
   std::cout << '[';
   for (int i = 0; i < nproc; i++)
@@ -343,24 +381,29 @@ void show_json_trace(Line *lines[], int nproc) {
   }
   std::cout << ']' << std::endl;
 }
-void show_trace(Line *lines[], int nproc) {
+
+void show_trace(Line *lines[], int nproc)
+{
   std::cout << "\nRefreshing:\n";
 
   /* print them */
-  for (int i = 0; i < nproc; i++) {
+  for (int i = 0; i < nproc; i++)
+  {
     lines[i]->log();
     delete lines[i];
   }
 
   /* print the 'unknown' connections, for debugging */
   for (auto it = unknowntcp->connections.begin();
-       it != unknowntcp->connections.end(); ++it) {
+       it != unknowntcp->connections.end(); ++it)
+  {
     std::cout << "Unknown connection: " << (*it)->refpacket->gethashstring()
               << std::endl;
   }
 }
 
-void show_ncurses(Line *lines[], int nproc) {
+void show_ncurses(Line *lines[], int nproc)
+{
   int rows;             // number of terminal rows
   int cols;             // number of terminal columns
   unsigned int proglen; // max length of the "PROGRAM" column
@@ -370,7 +413,8 @@ void show_ncurses(Line *lines[], int nproc) {
 
   getmaxyx(stdscr, rows, cols); /* find the boundaries of the screen */
 
-  if (cols < 62) {
+  if (cols < 62)
+  {
     erase();
     mvprintw(0, 0,
              "The terminal is too narrow! Please make it wider.\nI'll wait...");
@@ -395,7 +439,8 @@ void show_ncurses(Line *lines[], int nproc) {
 
   /* print them */
   int i;
-  for (i = 0; i < nproc; i++) {
+  for (i = 0; i < nproc; i++)
+  {
     if (i + 3 < rows)
       lines[i]->show(i + 3, proglen, devlen);
     recv_global += lines[i]->recv_value;
@@ -413,12 +458,14 @@ void show_ncurses(Line *lines[], int nproc) {
 }
 
 // Display all processes and relevant network traffic using show function
-void do_refresh() {
+void do_refresh()
+{
   refreshconninode();
   refreshcount++;
 
   if (viewMode == VIEWMODE_KBPS || viewMode == VIEWMODE_MBPS ||
-      viewMode == VIEWMODE_GBPS) {
+      viewMode == VIEWMODE_GBPS)
+  {
     remove_timed_out_processes();
   }
 
@@ -432,7 +479,8 @@ void do_refresh() {
 
   int n = 0;
 
-  while (curproc != NULL) {
+  while (curproc != NULL)
+  {
     // walk though its connections, summing up their data, and
     // throwing away connections that haven't received a package
     // in the last CONNTIMEOUT seconds.
@@ -441,19 +489,32 @@ void do_refresh() {
 
     float value_sent = 0, value_recv = 0;
 
-    if (viewMode == VIEWMODE_KBPS) {
+    if (viewMode == VIEWMODE_KBPS)
+    {
       curproc->getVal()->getkbps(&value_recv, &value_sent);
-    } else if (viewMode == VIEWMODE_MBPS) {
+    }
+    else if (viewMode == VIEWMODE_MBPS)
+    {
       curproc->getVal()->getmbps(&value_recv, &value_sent);
-    } else if (viewMode == VIEWMODE_GBPS) {
+    }
+    else if (viewMode == VIEWMODE_GBPS)
+    {
       curproc->getVal()->getgbps(&value_recv, &value_sent);
-    } else if (viewMode == VIEWMODE_TOTAL_KB) {
+    }
+    else if (viewMode == VIEWMODE_TOTAL_KB)
+    {
       curproc->getVal()->gettotalkb(&value_recv, &value_sent);
-    } else if (viewMode == VIEWMODE_TOTAL_MB) {
+    }
+    else if (viewMode == VIEWMODE_TOTAL_MB)
+    {
       curproc->getVal()->gettotalmb(&value_recv, &value_sent);
-    } else if (viewMode == VIEWMODE_TOTAL_B) {
+    }
+    else if (viewMode == VIEWMODE_TOTAL_B)
+    {
       curproc->getVal()->gettotalb(&value_recv, &value_sent);
-    } else {
+    }
+    else
+    {
       forceExit(false, "Invalid viewMode: %d", viewMode);
     }
     uid_t uid = curproc->getVal()->getUid();
@@ -469,9 +530,10 @@ void do_refresh() {
 
   /* sort the accumulated lines */
   qsort(lines, nproc, sizeof(Line *), GreatestFirst);
+
   if (jsontrace)
     show_json_trace(lines, nproc);
-  if (tracemode || DEBUG)
+  else if (tracemode || DEBUG)
     show_trace(lines, nproc);
   else
     show_ncurses(lines, nproc);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -154,7 +154,7 @@ int main(int argc, char **argv) {
   int garbage_collection_period = 50;
 
   int opt;
-  while ((opt = getopt(argc, argv, "Vhxtpsd:v:c:laf:Cbg:P:")) != -1) {
+  while ((opt = getopt(argc, argv, "Vhxtpsd:v:c:laf:Cbg:P:j")) != -1) {
     switch (opt) {
     case 'V':
       versiondisplay();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,7 +31,7 @@ static void help(bool iserror) {
   // output << "usage: nethogs [-V] [-b] [-d seconds] [-t] [-p] [-f (eth|ppp))]
   // [device [device [device ...]]]\n";
   output << "usage: nethogs [-V] [-h] [-x] [-d seconds] [-v mode] [-c count] "
-            "[-t] [-p] [-s] [-a] [-l] [-f filter] [-C] [-b] [-P pid] "
+            "[-t] [-j] [-p] [-s] [-a] [-l] [-f filter] [-C] [-b] [-P pid] "
             "[device [device [device ...]]]\n";
   output << "		-V : prints version.\n";
   output << "		-h : prints this help.\n";
@@ -42,6 +42,7 @@ static void help(bool iserror) {
             "total bytes, 3 = total MB, 4 = MB/s, 5 = GB/s). default is 0.\n";
   output << "		-c : number of updates. default is 0 (unlimited).\n";
   output << "		-t : tracemode.\n";
+  output << "		-j : tracemode with data as newline-delimited json.\n";
   // output << "		-f : format of packets on interface, default is
   // eth.\n";
   output << "		-p : sniff in promiscious mode (not recommended).\n";
@@ -166,6 +167,10 @@ int main(int argc, char **argv) {
       tracemode = true;
       break;
     case 't':
+      tracemode = true;
+      break;
+    case 'j':
+      jsontrace = true;
       tracemode = true;
       break;
     case 'p':

--- a/src/nethogs.cpp
+++ b/src/nethogs.cpp
@@ -40,7 +40,8 @@
 
 #include "cui.h"
 
-extern "C" {
+extern "C"
+{
 #include "decpcap.h"
 }
 
@@ -67,7 +68,8 @@ int viewMode = VIEWMODE_KBPS;
 const char version[] = " version " VERSION;
 timeval curtime;
 
-bool local_addr::contains(const in_addr_t &n_addr) {
+bool local_addr::contains(const in_addr_t &n_addr)
+{
   if ((sa_family == AF_INET) && (n_addr == addr))
     return true;
   if (next == NULL)
@@ -75,8 +77,10 @@ bool local_addr::contains(const in_addr_t &n_addr) {
   return next->contains(n_addr);
 }
 
-bool local_addr::contains(const struct in6_addr &n_addr) {
-  if (sa_family == AF_INET6) {
+bool local_addr::contains(const struct in6_addr &n_addr)
+{
+  if (sa_family == AF_INET6)
+  {
     /*
     if (DEBUG) {
             char addy [50];
@@ -88,7 +92,8 @@ bool local_addr::contains(const struct in6_addr &n_addr) {
     }
     */
     // if (addr6.s6_addr == n_addr.s6_addr)
-    if (memcmp(&addr6, &n_addr, sizeof(struct in6_addr)) == 0) {
+    if (memcmp(&addr6, &n_addr, sizeof(struct in6_addr)) == 0)
+    {
       if (DEBUG)
         std::cerr << "Match!" << std::endl;
       return true;
@@ -99,7 +104,8 @@ bool local_addr::contains(const struct in6_addr &n_addr) {
   return next->contains(n_addr);
 }
 
-struct dpargs {
+struct dpargs
+{
   const char *device;
   int sa_family;
   in_addr ip_src;
@@ -111,7 +117,8 @@ struct dpargs {
 const char *getVersion() { return version; }
 
 int process_tcp(u_char *userdata, const dp_header *header,
-                const u_char *m_packet) {
+                const u_char *m_packet)
+{
   struct dpargs *args = (struct dpargs *)userdata;
   struct tcphdr *tcp = (struct tcphdr *)m_packet;
 
@@ -119,7 +126,8 @@ int process_tcp(u_char *userdata, const dp_header *header,
 
   /* get info from userdata, then call getPacket */
   Packet *packet;
-  switch (args->sa_family) {
+  switch (args->sa_family)
+  {
   case AF_INET:
 #if defined(__APPLE__) || defined(__FreeBSD__)
     packet = new Packet(args->ip_src, ntohs(tcp->th_sport), args->ip_dst,
@@ -146,10 +154,13 @@ int process_tcp(u_char *userdata, const dp_header *header,
 
   Connection *connection = findConnection(packet, IPPROTO_TCP);
 
-  if (connection != NULL) {
+  if (connection != NULL)
+  {
     /* add packet to the connection */
     connection->add(packet);
-  } else {
+  }
+  else
+  {
     /* else: unknown connection, create new */
     connection = new Connection(packet);
     getProcess(connection, args->device, IPPROTO_TCP);
@@ -161,14 +172,16 @@ int process_tcp(u_char *userdata, const dp_header *header,
 }
 
 int process_udp(u_char *userdata, const dp_header *header,
-                const u_char *m_packet) {
+                const u_char *m_packet)
+{
   struct dpargs *args = (struct dpargs *)userdata;
   struct udphdr *udp = (struct udphdr *)m_packet;
 
   curtime = header->ts;
 
   Packet *packet;
-  switch (args->sa_family) {
+  switch (args->sa_family)
+  {
   case AF_INET:
 #if defined(__APPLE__) || defined(__FreeBSD__)
     packet = new Packet(args->ip_src, ntohs(udp->uh_sport), args->ip_dst,
@@ -198,10 +211,13 @@ int process_udp(u_char *userdata, const dp_header *header,
 
   Connection *connection = findConnection(packet, IPPROTO_UDP);
 
-  if (connection != NULL) {
+  if (connection != NULL)
+  {
     /* add packet to the connection */
     connection->add(packet);
-  } else {
+  }
+  else
+  {
     /* else: unknown connection, create new */
     connection = new Connection(packet);
     getProcess(connection, args->device, IPPROTO_UDP);
@@ -213,7 +229,8 @@ int process_udp(u_char *userdata, const dp_header *header,
 }
 
 int process_ip(u_char *userdata, const dp_header * /* header */,
-               const u_char *m_packet) {
+               const u_char *m_packet)
+{
   struct dpargs *args = (struct dpargs *)userdata;
   struct ip *ip = (struct ip *)m_packet;
   args->sa_family = AF_INET;
@@ -225,7 +242,8 @@ int process_ip(u_char *userdata, const dp_header * /* header */,
 }
 
 int process_ip6(u_char *userdata, const dp_header * /* header */,
-                const u_char *m_packet) {
+                const u_char *m_packet)
+{
   struct dpargs *args = (struct dpargs *)userdata;
   const struct ip6_hdr *ip6 = (struct ip6_hdr *)m_packet;
   args->sa_family = AF_INET6;
@@ -236,9 +254,11 @@ int process_ip6(u_char *userdata, const dp_header * /* header */,
   return false;
 }
 
-class handle {
+class handle
+{
 public:
-  handle(dp_handle *m_handle, const char *m_devicename = NULL) {
+  handle(dp_handle *m_handle, const char *m_devicename = NULL)
+  {
     content = m_handle;
     devicename = m_devicename;
   }

--- a/src/nethogs.cpp
+++ b/src/nethogs.cpp
@@ -57,6 +57,7 @@ unsigned refreshcount = 0;
 unsigned processlimit = 0;
 bool tracemode = false;
 bool bughuntmode = false;
+bool jsontrace = false;
 // sort on sent or received?
 bool sortRecv = true;
 bool showcommandline = false;

--- a/src/nethogs.h
+++ b/src/nethogs.h
@@ -63,7 +63,8 @@
 #define PROGNAME_WIDTH 512
 
 // viewMode: how to represent numbers
-enum {
+enum
+{
   VIEWMODE_KBPS,
   VIEWMODE_TOTAL_KB,
   VIEWMODE_TOTAL_B,
@@ -77,13 +78,14 @@ enum {
 
 // 'extern' declarations for jsontrace variable
 extern bool jsontrace;
-
 void forceExit(bool success, const char *msg, ...) NORETURN;
 
-class local_addr {
+class local_addr
+{
 public:
   /* ipv4 constructor takes an in_addr_t */
-  local_addr(in_addr_t m_addr, local_addr *m_next = NULL) {
+  local_addr(in_addr_t m_addr, local_addr *m_next = NULL)
+  {
     addr = m_addr;
     next = m_next;
     sa_family = AF_INET;
@@ -91,7 +93,8 @@ public:
     inet_ntop(AF_INET, &m_addr, string, 15);
   }
   /* this constructor takes an char address[33] */
-  local_addr(struct in6_addr *m_addr, local_addr *m_next = NULL) {
+  local_addr(struct in6_addr *m_addr, local_addr *m_next = NULL)
+  {
     addr6 = *m_addr;
     next = m_next;
     sa_family = AF_INET6;

--- a/src/nethogs.h
+++ b/src/nethogs.h
@@ -75,6 +75,9 @@ enum {
 
 #define NORETURN __attribute__((__noreturn__))
 
+// 'extern' declarations for jsontrace variable
+extern bool jsontrace;
+
 void forceExit(bool success, const char *msg, ...) NORETURN;
 
 class local_addr {


### PR DESCRIPTION
This pull request introduces a new `-j` option that allows users to receive network traffic data in newline-delimited JSON format. This feature is intended for users who wish to parse the output programmatically.

Changes include:
- A new command-line option `-j` that enables JSON formatted output.
- The `jsontrace` variable to toggle JSON trace mode.
- A new function `show_json_trace` for displaying information in JSON.
- A utility function `log_json` for structured logging.

The feature has been tested on Ubuntu 22.04, and Ubuntu 20.4 and includes error handling to ensure robustness.

Please let me know if there are any adjustments I should make. I am looking forward to your feedback!