### PR TITLE
Fix nethogsmonitor_loop_devices_py to accept more than one device

### DIFF
--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -52,7 +52,10 @@ int nethogsmonitor_loop_devices_py(
 {
     // this is ok because we only use the vector here
     std::vector<char*> _devicenames;
-    for (auto _dn : __devicenames) _devicenames.push_back(const_cast<char*>(_dn.c_str()));
+    for (auto& _dn : __devicenames)
+    {
+      _devicenames.push_back(const_cast<char*>(_dn.c_str()));
+    } 
     int devc = _devicenames.size();
     char **devicenames = (_devicenames.empty()) ? NULL : _devicenames.data();
 


### PR DESCRIPTION
Without the ref only the last element of `__devicenames` is stored in `_devicenames`: The temporary is deleted at the end of the for body, therefore the pointer to the `c_str` is no longer valid and might be reused by the implementation. By using a reference in the for head the `c_str` does not return a ref to the temporary but to the original array wich's lifetime is till the end of the function.