### PR TITLE
Modify cui.cpp and inode2prog.cpp

### DIFF
--- a/src/cui.cpp
+++ b/src/cui.cpp
@@ -158,9 +158,12 @@ static void mvaddstr_truncate_cmdline(int row, int col, const char *progname,
                                       const char *cmdline,
                                       std::size_t max_len) {
   if (showBasename) {
-    if (index(progname, FILE_SEPARATOR) != NULL) {
+/*    if (index(progname, FILE_SEPARATOR) != NULL) {
       progname = rindex(progname, FILE_SEPARATOR) + 1;
-    }
+    } */
+      char *program_basename = strrchr((char *)progname, FILE_SEPARATOR);
+      if (program_basename != NULL)
+        progname = program_basename + 1;
   }
 
   std::size_t proglen = strlen(progname);

--- a/src/inode2prog.cpp
+++ b/src/inode2prog.cpp
@@ -226,10 +226,10 @@ void get_info_for_pid(const char *pid) {
   closedir(dir);
 }
 
-static quad_t get_ms() {
+static int64_t get_ms() {
   struct timespec ts;
   clock_gettime(CLOCK_MONOTONIC, &ts);
-  return static_cast<quad_t>(ts.tv_sec) * 1000 + ts.tv_nsec / 1000000;
+  return static_cast<int64_t>(ts.tv_sec) * 1000 + ts.tv_nsec / 1000000;
 }
 
 static void get_pids(std::set<pid_t> *pids) {
@@ -253,8 +253,8 @@ static void get_pids(std::set<pid_t> *pids) {
 }
 
 void garbage_collect_inodeproc() {
-  static quad_t last_ms = 0;
-  quad_t start_ms = 0;
+  static int64_t last_ms = 0;
+  int64_t start_ms = 0;
   if (bughuntmode) {
     start_ms = get_ms();
     if (last_ms) {


### PR DESCRIPTION
cui.cpp:
The index and rindex in the mvaddstr_truncate_cmdline()
function are changed to strrchar.

inode2prog.cpp:
The quad_t type is modified to int64_t.