### PR TITLE
Add meson buildsystem

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,46 @@
+#
+# See COPYING for more information about licensing
+#
+
+project('nethogs',
+        ['c', 'cpp'],
+        default_options : ['warning_level=3',
+                           'cpp_std=c++14']
+        )
+
+cc = meson.get_compiler('cpp')
+version = run_command('./determineVersion.sh', check: true).stdout().strip()
+
+#######################################
+## Dependencies and flags definition ##
+#######################################
+# directories
+projectinc = [include_directories('.', 'src')]
+
+# flags
+c_args = [
+  '-DVERSION="' + version + '"'
+]
+
+# dependencies
+thread_dep = dependency('threads', required: true)
+libpcap_dep = dependency('libpcap', required: true)
+project_deps = [
+  thread_dep,
+  libpcap_dep
+]
+
+#############################
+## Code Compilation        ##
+#############################
+subdir('src')
+
+#############################
+## Pkgconfig definition    ##
+#############################
+pkgconfig = import('pkgconfig')
+pkgconfig_install_dir = join_paths(get_option('libdir'), 'pkgconfig')
+pkgconfig.generate(libnethogs,
+                   requires: ['libpcap'],
+                   version: version
+                   )

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,2 @@
+option('enable-libnethogs', type: 'feature', value: 'enabled', description: 'Enable libnethogs library')
+option('enable-nethogs-app', type: 'feature', value: 'enabled', description: 'Enable nethogs application')

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,0 +1,67 @@
+#
+# See COPYING for more information about licensing
+#
+
+sources = [
+  files([
+    'connection.cpp',
+    'conninode.cpp',
+    'decpcap.c',
+    'devices.cpp',
+    'inode2prog.cpp',
+    'packet.cpp',
+    'process.cpp',
+  ])
+]
+
+# --- Executable Compilation ---
+
+if get_option('enable-nethogs-app').enabled()
+  app_sources = [
+    files([
+      'main.cpp',
+      'cui.cpp',
+    ])
+  ]
+
+  cursespp_dep = dependency('ncurses++', required: true)
+  curses_dep = dependency('ncurses', required: true)
+
+  executable('nethogs',
+    [app_sources + sources],
+    include_directories: [projectinc],
+    cpp_args: c_args,
+    c_args: c_args,
+    install: true,
+    dependencies : [project_deps, cursespp_dep, curses_dep]
+  )
+endif
+
+# --- Library Compilation ---
+
+if get_option('enable-libnethogs').enabled()
+  lib_sources = [
+    files([
+      'libnethogs.cpp',
+    ])
+  ]
+
+  libnethogs = shared_library('libnethogs' ,
+    sources + lib_sources, 
+    cpp_args: c_args,
+    c_args: c_args,
+    install: true,
+    soversion: meson.project_version(),
+    include_directories: [projectinc],
+    dependencies: [project_deps]
+  )
+  
+  libnethogs_dep = declare_dependency(link_with: libnethogs)
+
+  # --- Header Installation ---
+
+  lib_headers = [
+    files('libnethogs.h'),
+  ]
+  install_headers(lib_headers, subdir : 'libnethogs')
+endif


### PR DESCRIPTION
This feature:

* Adds the meson building system
* Adds the option to compile the library and the application or just the library

Instructions:

```bash
# Create project
meson builddir -Denable-nethogs-app=enabled -Denable-libnethogs=disabled
# Compile
ninja -C builddir
# Install
ninja -C builddir install
```