### PR TITLE
determineVersion.sh: prevent traversing into outer git repo for git-describe call

### DIFF
--- a/determineVersion.sh
+++ b/determineVersion.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
-
-(git describe --tags 2>/dev/null || pwd | sed -e "s/.*\\///" | sed -e "s/[^-]*//") | tail -c +2
+if [ $(git rev-parse --show-toplevel 2>/dev/null) == $(pwd) ]; then
+  git describe --tags 2>/dev/null | tail -c +2
+else
+  pwd | sed -e "s/.*\\///" | sed -e "s/[^-]*//" | tail -c +2
+fi


### PR DESCRIPTION
When building nethogs inside another git repo (as is i.e. done as part of a buildroot build) the version is picked up from the outer git repo, which is confusing as well as introducing reproducibility problems when rebuilding the same nethogs version produces different results if the outer repository changes.