### PR TITLE
Optimize UDP packet statistics collection and clear hashstring in Packet::onlySource()

### DIFF
--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -172,17 +172,7 @@ Connection *findConnectionWithMatchingRefpacketOrSource(Packet *packet,
                                                         short int packettype) {
 
   ConnList *connList = NULL;
-  switch (packettype) {
-  case IPPROTO_TCP: {
-    connList = &connections;
-    break;
-  }
-
-  case IPPROTO_UDP: {
-    connList = &unknownudp->connections;
-    break;
-  }
-  }
+  connList = &connections;
 
   auto it = connList->lower_bound(packet);
   /* the reference packet is always *outgoing* */

--- a/src/packet.cpp
+++ b/src/packet.cpp
@@ -309,6 +309,10 @@ Packet Packet::onlySource() const {
   std::fill(std::begin(p.dip6.s6_addr), std::end(p.dip6.s6_addr), 0);
   p.dip.s_addr = 0;
   p.dport = 0;
+  if (p.hashstring != NULL) {
+    free(p.hashstring);
+    p.hashstring = NULL;
+  }
   return p;
 }
 

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -341,6 +341,12 @@ Process *getProcess(Connection *connection, const char *devicename,
 #endif
     refreshconninode();
     inode = conninode[connection->refpacket->gethashstring()];
+
+    if(inode == 0 && packettype == IPPROTO_UDP){
+      Packet p = connection->refpacket->onlySource();
+      inode = conninode[p.gethashstring()];
+    }
+
     if (bughuntmode) {
       if (inode == 0) {
         std::cout << ":( inode for connection not found after refresh.\n";


### PR DESCRIPTION
Hi,

I'm using this in my program on ubuntu, and recently I found that it can not show the pid of udp packets sometimes, then I look up the code carefully, and found it may concerned about the conninode_udp which got from /proc/net/udp,  the rem_address in this file is sometimes empty, so the hashstring saved in conninode_udp sometimes may not accurate(**only have source address**), and when use conninode_udp  in getProcess, the value somethimes may could't found, cause the hash key here is the full(which **has both source addr and dest addr** extracted from the info captured from libpcap), so it was added to the unknownudp; I think its inapposite, maybe use onlySource as key is better here?
![image](https://github.com/user-attachments/assets/19f23498-14e4-4763-b102-d65b653bc127)

Also, I've found that in Packet::onlySource(), the hashstring of new packet is forgot to release.

Hope this helps. Best regards.
