### PR TITLE
meson: fix library name

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -39,7 +39,7 @@ if get_option('enable-libnethogs').enabled()
     lib_sources = [files('libnethogs.cpp')]
 
     libnethogs = shared_library(
-        'libnethogs' ,
+        'nethogs' ,
         sources + lib_sources,
         cpp_args: c_args,
         c_args: c_args,


### PR DESCRIPTION
Meson automatically adds the lib prefix, so this fix ensures that `libnethogs.so` is generated instead of `liblibnethogs.so`