### PR TITLE
Add missing security flags and include CPPFLAGS in libnethogs

### DIFF
--- a/src/MakeLib.mk
+++ b/src/MakeLib.mk
@@ -97,11 +97,11 @@ $(ODIR)/conninode.o: conninode.cpp nethogs.h conninode.h
 
 $(ODIR)/devices.o: devices.cpp devices.h
 	@mkdir -p $(ODIR)
-	$(CXX) $(CXXFLAGS) -o $@ -c devices.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -o $@ -c devices.cpp
 
 $(ODIR)/libnethogs.o: libnethogs.cpp libnethogs.h
 	@mkdir -p $(ODIR)
-	$(CXX) $(CXXFLAGS) -o $@ -c libnethogs.cpp -DVERSION=\"$(LIBVERSION)\"
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -o $@ -c libnethogs.cpp -DVERSION=\"$(LIBVERSION)\"
 
 .PHONY: clean
 clean:

--- a/src/MakeLib.mk
+++ b/src/MakeLib.mk
@@ -10,7 +10,7 @@ all: $(LIBNAME) libnethogs.a
 
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Linux)
-  LDFLAGS:= -shared -Wl,-soname,$(SO_NAME)
+  LDFLAGS:= -shared -Wl,-soname,$(SO_NAME) -Wl,-z,now -Wl,-z,relro
 else ifeq ($(UNAME_S),FreeBSD)
   LDFLAGS:= -shared -Wl,-soname,$(SO_NAME)
 else


### PR DESCRIPTION
I'm adding `libnethogs` to the `nethogs` package in Debian to provide a shared library that allows other applications to use `nethogs`, I'm also ensuring that the build system includes the necessary security and hardening flags:  

- **Add security flags to `LDFLAGS` for Linux**  
  `blhc` detected that `-Wl,-z,relro -Wl,-z,now` were missing during linking.  
  Now, these flags are correctly applied when building `libnethogs.so`.  

- **Include `$(CPPFLAGS)` for `devices.cpp` and `libnethogs.cpp`**  
  `blhc` reported missing `-D_FORTIFY_SOURCE=2` in `CPPFLAGS`.  
  The build system now properly includes `$(CPPFLAGS)`.

There might be additional flags that Debian automatically applies during the build process.  