### PR TITLE
Allow overriding VERSION from environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-export VERSION := $(shell ./determineVersion.sh)
+export VERSION ?= $(shell ./determineVersion.sh)
 
 #export PREFIX := /usr
 export PREFIX ?= /usr/local


### PR DESCRIPTION
Use ?= instead of := when setting VERSION in the Makefile. This lets pass VERSION without needing to modify the file during build.