### PR TITLE
fix: add u_char/u_short/u_int typedefs for GCC 15 / C23 compatibility

### DIFF
--- a/src/decpcap.h
+++ b/src/decpcap.h
@@ -22,6 +22,19 @@
 #ifndef __DECPCAP_H
 #define __DECPCAP_H
 
+/* Compatibility typedefs — u_char/u_short/u_int were removed
+   from <sys/types.h> in C23 (GCC 15 default -std=gnu23).
+   Must come before <pcap.h> because libpcap uses these types. */
+#ifndef u_char
+typedef unsigned char u_char;
+#endif
+#ifndef u_short
+typedef unsigned short u_short;
+#endif
+#ifndef u_int
+typedef unsigned int u_int;
+#endif
+
 #include <pcap.h>
 #include <stdbool.h>
 #include <stdio.h>

--- a/src/decpcap.h
+++ b/src/decpcap.h
@@ -24,7 +24,8 @@
 
 /* Compatibility typedefs — u_char/u_short/u_int were removed
    from <sys/types.h> in C23 (GCC 15 default -std=gnu23).
-   Must come before <pcap.h> because libpcap uses these types. */
+   Must come before <pcap.h> because libpcap uses these types.
+   Upstream libpcap C23 compat: https://github.com/the-tcpdump-group/libpcap/issues/1679 */
 #ifndef u_char
 typedef unsigned char u_char;
 #endif


### PR DESCRIPTION
Under GCC 15 the default C standard is `-std=gnu23` (C23), which removes `u_char`, `u_short`, and `u_int` from `<sys/types.h>`. The libpcap `<pcap.h>` header and nethogs' own `decpcap.h` both use these types, causing a cascade of "unknown type name" errors.

This adds compatibility typedefs guarded by `#ifndef` **before** the `pcap.h` include so they are visible both to libpcap and to the rest of `decpcap.h`.

Tested: builds cleanly with GCC 13 `-std=c2x` (the GCC 13 name for C23 mode) and `-D_DEFAULT_SOURCE`, and with the default `-std=c++14` build.

Fixes #287.