### PR TITLE
Fix exit-with-error accessing /proc on macOS

### DIFF
--- a/src/MakeLib.mk
+++ b/src/MakeLib.mk
@@ -108,5 +108,4 @@ clean:
 	rm -f $(OBJS)
 	rm -f $(LIBNAME)
 	rm -f libnethogs.a
-	mkdir -p $(ODIR)
-	rmdir -p --ignore-fail-on-non-empty $(ODIR)
+	rmdir -p $(ODIR) 2>/dev/null || true

--- a/src/conninode.cpp
+++ b/src/conninode.cpp
@@ -188,25 +188,25 @@ void refreshconninode() {
   // delete conninode;
   // conninode = new HashTable (256);
 
-#if defined(__APPLE__) || defined(__FreeBSD__)
-  addprocinfo("net.inet.tcp.pcblist", conninode_tcp);
-#else
+#ifdef NETHOGS_HAVE_PROC
   if (!addprocinfo("/proc/net/tcp", conninode_tcp)) {
     std::cout << "Error: couldn't open /proc/net/tcp\n";
     exit(0);
   }
   addprocinfo("/proc/net/tcp6", conninode_tcp);
+#else
+  addprocinfo("net.inet.tcp.pcblist", conninode_tcp);
 #endif
 
   if (catchall) {
-#if defined(__APPLE__) || defined(__FreeBSD__)
-    addprocinfo("net.inet.udp.pcblist", conninode_udp);
-#else
+#ifdef NETHOGS_HAVE_PROC
     if (!addprocinfo("/proc/net/udp", conninode_udp)) {
       std::cout << "Error: couldn't open /proc/net/udp\n";
       exit(0);
     }
     addprocinfo("/proc/net/udp6", conninode_udp);
+#else
+    addprocinfo("net.inet.udp.pcblist", conninode_udp);
 #endif
   }
 

--- a/src/inode2prog.cpp
+++ b/src/inode2prog.cpp
@@ -227,6 +227,7 @@ void get_info_for_pid(const char *pid) {
   closedir(dir);
 }
 
+#ifdef NETHOGS_HAVE_PROC
 static quad_t get_ms() {
   struct timespec ts;
   clock_gettime(CLOCK_MONOTONIC, &ts);
@@ -252,8 +253,14 @@ static void get_pids(std::set<pid_t> *pids) {
   }
   closedir(proc);
 }
+#endif /* NETHOGS_HAVE_PROC */
 
 void garbage_collect_inodeproc() {
+#ifndef NETHOGS_HAVE_PROC
+  /* No /proc to enumerate live pids against; the inode->pid table is never
+   * populated on these platforms, so there is nothing to collect. */
+  return;
+#else
   static quad_t last_ms = 0;
   quad_t start_ms = 0;
   if (bughuntmode) {
@@ -292,6 +299,7 @@ void garbage_collect_inodeproc() {
     std::cout << "PERF: GC proctime: " << last_ms - start_ms << "[ms]"
               << std::endl;
   }
+#endif
 }
 
 /* updates the `inodeproc' inode-to-prg_node mapping
@@ -329,7 +337,7 @@ struct prg_node *findPID(unsigned long inode) {
     return node;
   }
 
-#ifndef __APPLE__
+#ifdef NETHOGS_HAVE_PROC
   reread_mapping();
 #endif
 

--- a/src/nethogs.h
+++ b/src/nethogs.h
@@ -40,6 +40,15 @@
 
 #define _BSD_SOURCE 1
 
+/* Linux exposes the connection->inode and inode->pid mappings through the
+ * /proc filesystem; macOS and the BSDs do not (and their native procfs, when
+ * present, has a different layout). Gate every /proc-based lookup on this
+ * single feature macro so the BSD-family builds stay connections-only (as the
+ * README advertises) instead of aborting on a missing /proc. */
+#if !defined(__APPLE__) && !defined(__FreeBSD__)
+#define NETHOGS_HAVE_PROC 1
+#endif
+
 /* take the average speed over the last 5 seconds */
 #define PERIOD 5
 

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -336,7 +336,7 @@ Process *getProcess(Connection *connection, const char *devicename,
 // We take the fact for granted that we might already know the inode->pid
 // (unlikely anyway if we
 // haven't seen the connection->inode yet though).
-#ifndef __APPLE__
+#ifdef NETHOGS_HAVE_PROC
     reread_mapping();
 #endif
     refreshconninode();


### PR DESCRIPTION
nethogs could exit with an error "Error reading /proc, needed to get pid set" when running on macOS (test was run on an installation from brew, reported version 0.8.8).

Tested
- [x] compiles and runs on macOS Tahoe, Ubuntu 26, FreeBSD 15

 
 Notes:
- Define NETHOGS_HAVE_PROC for non-Apple/non-FreeBSD platforms (room for expansion to other BSDs)
- Guard all /proc-based connection/inode and pid mapping paths behind the macro
- Skip /proc cleanup and GC logic on BSD/macOS builds while keeping behavior intact
- Use portable object-dir cleanup fallback in MakeLib
    
 