### PR TITLE
Fix 'Error opening terminal' with unknown TERM under sudo

### DIFF
--- a/src/cui.cpp
+++ b/src/cui.cpp
@@ -278,7 +278,17 @@ int GreatestFirst(const void *ma, const void *mb) {
 }
 
 void init_ui() {
-  WINDOW *screen = initscr();
+  SCREEN *term = newterm(NULL, stdout, stdin);
+  if (!term) {
+    term = newterm("xterm-256color", stdout, stdin);
+    if (!term) {
+        term = newterm("xterm", stdout, stdin);
+    }
+    if (!term) {
+        initscr();
+    }
+  }
+  WINDOW *screen = stdscr;
   cursOrig = curs_set(0);
   raw();
   noecho();


### PR DESCRIPTION
When running nethogs via sudo from a terminal emulator with a custom TERM (e.g., `TERM=xterm-kitty`), ncurses `initscr()` fails to open the terminal and abruptly aborts because root lacks the corresponding terminfo file.

This patch updates `init_ui` to use `newterm()` instead, providing a graceful fallback to standard `xterm-256color` or `xterm` terminal types. This ensures the interface can launch successfully without requiring the user to employ global terminfo hacks.

*Note on ncurses canon:* While standard ncurses canon is to fail loudly on unknown terminals, modern emulators (like Kitty/Alacritty) are largely xterm-compatible. This fallback provides a massive Quality-of-Life improvement for users running `sudo nethogs` who don't have their custom terminfo database replicated to the root user.