### PR TITLE
Exit on Ctrl-C in the curses UI

### DIFF
--- a/src/cui.cpp
+++ b/src/cui.cpp
@@ -310,6 +310,7 @@ void exit_ui() {
 void ui_tick() {
   switch (getch()) {
   case 'q':
+  case 3:
     /* quit */
     quit_cb(0);
     break;


### PR DESCRIPTION
Fixes #84 

Pressing Ctrl-C in the curses UI sends keyboard byte 0x03, not SIGINT, preventing the application from exiting. This fixes it by calling `quit_cb` in `ui_tick` when `getch()` returns 3.