### PR TITLE
Replace inet_ntoa with inet_ntop

### DIFF
--- a/src/packet.cpp
+++ b/src/packet.cpp
@@ -71,7 +71,9 @@ bool getLocal(const char *device, bool tracemode) {
       local_addrs = new local_addr(addr->sin_addr.s_addr, local_addrs);
 
       if (tracemode || DEBUG) {
-        printf("Adding local address: %s\n", inet_ntoa(addr->sin_addr));
+        char host[INET_ADDRSTRLEN];
+        const char *addrstr = inet_ntop(AF_INET, &addr->sin_addr, host, sizeof(host));
+        printf("Adding local address: %s\n", addrstr ? addrstr : "<invalid>");
       }
     } else if (family == AF_INET6) {
       struct sockaddr_in6 *addr = (struct sockaddr_in6 *)ifa->ifa_addr;


### PR DESCRIPTION
inet_ntoa() returns a pointer to static storage and is considered deprecated/problematic by static analysis tools. Fedora rpminspect flags it as a forbidden function.

Use inet_ntop() for IPv4 trace output instead, matching the existing IPv6 code path.

This helps avoid rpminspect badfuncs failures without changing runtime behavior.

Local validation performed:
- Clean `make nethogs` build passed
- `git grep inet_ntoa` finds no remaining references
- `nm -D src/nethogs` shows `inet_ntop` and no `inet_ntoa`
- Smoke-tested documented options in an isolated network namespace
- Generated loopback TCP traffic and confirmed nethogs traced python3 processes with nonzero traffic